### PR TITLE
QI.bu6ofkm: Triage tools for a bad Space

### DIFF
--- a/querki/build.sbt
+++ b/querki/build.sbt
@@ -7,7 +7,7 @@ lazy val clients = Seq(querkiClient)
 lazy val scalaV = "2.11.12"
 lazy val akkaV = "2.4.18"
 lazy val enumeratumV = "1.5.3"
-lazy val appV = "2.9.3.1"
+lazy val appV = "2.9.4"
 
 lazy val sharedSrcDir = "scala"
 

--- a/querki/scalajvm/app/controllers/ApplicationBase.scala
+++ b/querki/scalajvm/app/controllers/ApplicationBase.scala
@@ -205,6 +205,7 @@ trait ApplicationBase extends Controller with EcologyMember {
         case ClientResponse(pickled) => Future.successful(pickled)
         case ClientError(msg) => Future.failed(new Exception(msg))
         case ThingError(pex, _) => Future.failed(pex)
+        case pex: PublicException => Future.failed(pex)
       }
     }
     

--- a/querki/scalajvm/app/querki/admin/AdminEcot.scala
+++ b/querki/scalajvm/app/querki/admin/AdminEcot.scala
@@ -30,6 +30,7 @@ private[admin] object MOIDs extends EcotIds(43) {
   val InspectByEmailCmdOID = moid(4)
   val DeleteEmailAddressCmdOID = moid(5)
   val ShowThingCmdOID = moid(6)
+  val ShowSpaceIdCmdOID = moid(7)
 }
 
 private[admin] trait AdminInternal extends EcologyInterface {

--- a/querki/scalajvm/app/querki/spaces/PersistentSpaceActor.scala
+++ b/querki/scalajvm/app/querki/spaces/PersistentSpaceActor.scala
@@ -49,6 +49,8 @@ class PersistentSpaceActor(e:Ecology, val id:OID, stateRouter:ActorRef, persiste
   
   /**
    * Iff set to true, this will produce *prodigious* spewage. Use with caution!
+   *
+   * Deprecated: use the less-horrifying TracingSpace instead.
    */
   lazy val monitorSpaces = Config.getBoolean("querki.test.traceSpaces", false)
   

--- a/querki/scalajvm/app/querki/spaces/TracingSpace.scala
+++ b/querki/scalajvm/app/querki/spaces/TracingSpace.scala
@@ -1,0 +1,22 @@
+package querki.spaces
+
+import querki.ecology.Ecology
+import querki.globals.OID
+import querki.util.{Config, QLog}
+
+/**
+ * Provides deep trace capability for a given Space.
+ *
+ * To use this, create a TracingSpace val in the object/class in question, and then use its trace()
+ * liberally. The trace spews will be turned on by setting `querki.debug.space.[spaceId].trace` to true.
+ * This call is cheap unless the flag is turned on, so go wild.
+ */
+case class TracingSpace(spaceId: OID)(implicit ecology: Ecology) {
+  lazy val tracing: Boolean = Config.getBoolean(s"querki.debug.space.${spaceId.toString}.trace", false)
+
+  def trace(msg: => String): Unit = {
+    if (tracing) {
+      QLog.spew(s"TRACE $spaceId: $msg")
+    }
+  }
+}

--- a/querki/scalajvm/app/querki/spaces/messages/SpaceMessages.scala
+++ b/querki/scalajvm/app/querki/spaces/messages/SpaceMessages.scala
@@ -185,6 +185,7 @@ case object PersonReplaced
 
 // This is the most common response when you create/fetch any sort of Thing
 sealed trait SpaceResponse
+case class SpaceBlocked(error: PublicException)
 sealed trait ThingResponse extends SpaceResponse
 case class ThingFound(id:OID, state:SpaceState) extends ThingResponse
 case class ThingError(ex:PublicException, stateOpt:Option[SpaceState] = None) extends ThingResponse

--- a/querki/scalajvm/conf/application.conf.template
+++ b/querki/scalajvm/conf/application.conf.template
@@ -133,6 +133,19 @@ querki {
   invitations {
     inviteTimeout : 5 minutes
   }
+
+
+  debug {
+    space {
+# To deal with a problematic Space, put in a section here with its OID:
+#      7w4g7wj {
+# Trace turns on voluminous tracing about that Space
+#        trace : true
+# Block prevents that Space's Actors from being loaded
+#        block : false
+#      }
+    }
+  }
 }
 
 play.http.session {

--- a/querki/scalajvm/conf/messages
+++ b/querki/scalajvm/conf/messages
@@ -54,6 +54,8 @@ QL.unknownName=There is no Thing named "{0}" -- might be a typo? If you want to 
 QL.unknownThingId=There is no Thing with OID "{0}".
 QL.timeout=This took too long to display -- it might need to be simplified.
 
+Space.blocked=This Space is temporarily blocked. Sorry: we are working to resolve the situation.
+
 Space.create.alreadyExists=You already have a Space with the name {0}. Please choose a different name.
 Space.create.illegalName={0} is not a legal name for a Space. Space names should consist of just letters, digits and spaces.
 Space.create.maxSpaces=You are only allowed to create {0} Spaces at this time. This limit will be raised in the future.


### PR DESCRIPTION
Somehow, the GBLS Space has gotten corrupted in a way that is causing the entire cluster to fall over.  (It looks like it's getting into an infinite loop, blocking that node and generally causing havoc.)  So this introduces some tools to help me deal with that:

* A new Show Space Id admin command so that I can find the OID of a Space without loading it.
* Heavy tracing around a specified Space.
* A crude but hopefully functional mechanism to block a problematic Space from loading.
