### PR TITLE
QI.7w4g99h: Add the `_publish` function in QL

### DIFF
--- a/querki/scalajvm/test/querki/publication/PublicationMidFuncs.scala
+++ b/querki/scalajvm/test/querki/publication/PublicationMidFuncs.scala
@@ -1,0 +1,35 @@
+package querki.publication
+
+import autowire._
+
+import querki.data._
+import querki.globals.execContext
+import querki.test.mid._
+
+import AllFuncs._
+
+/**
+ * Not included in AllFuncs, since the functions here are relatively specialized and I don't want to pollute that
+ * namespace too much. Import or extend this explicitly if you want these.
+ */
+trait PublicationMidFuncs {
+
+  ///////////////////////////////////
+  //
+  // Wrappers around the PublicationFunctions API.
+  //
+
+  def publish(thingId:TID): TestOp[ThingInfo] =
+    TestOp.client { _[PublicationFunctions].publish(thingId).call() }
+
+  def update(thingId:TID, minor:Boolean): TestOp[ThingInfo] =
+    TestOp.client { _[PublicationFunctions].update(thingId, minor).call() }
+
+  def changePublishedModels(): TestOp[Unit] =
+    TestOp.client { _[PublicationFunctions].changePublishedModels().call() }
+
+  def discardChanges(thingId:TID): TestOp[Unit] =
+    TestOp.client { _[PublicationFunctions].discardChanges(thingId).call() }
+}
+
+object PublicationMidFuncs extends PublicationMidFuncs

--- a/querki/scalajvm/test/querki/publication/PublicationMidTests.scala
+++ b/querki/scalajvm/test/querki/publication/PublicationMidTests.scala
@@ -42,6 +42,13 @@ object PublicationMidTests {
 
       // Now the member should be able to see it:
       _ <- checkNameIsRealFor(instanceName, member)
+
+      // Now, try the same tests with another instance, publishing via QL instead:
+      instance2Name = "Next Instance"
+      instance2 <- makeThing(model, instance2Name)
+      _ <- checkNameIsMissingFor(instance2Name, member)
+      _ <- evaluateQL(instance2, "_publish")
+      _ <- checkNameIsRealFor(instance2Name, member)
     }
       yield ()
   }

--- a/querki/scalajvm/test/querki/publication/PublicationMidTests.scala
+++ b/querki/scalajvm/test/querki/publication/PublicationMidTests.scala
@@ -1,0 +1,59 @@
+package querki.publication
+
+import org.scalatest.tags.Slow
+import org.scalatest.Matchers._
+import querki.data.TID
+import querki.test.mid._
+import AllFuncs._
+import ClientState.withUser
+import PublicationMidFuncs._
+import querki.security.SecurityMidFuncs._
+
+object PublicationMidTests {
+  lazy val basicPublicationTests: TestOp[Unit] = {
+    val ownerName = "BasicPub Owner"
+    val owner = TestUser(ownerName)
+    val memberName = "BasicPub Member"
+    val member = TestUser(memberName)
+    val spaceName = "BasicPub Space"
+
+    for {
+      _ <- step("Basic Publication Test")
+      std <- getStd
+      _ <- newUser(owner)
+      space <- createSpace(spaceName)
+
+      _ <- newUser(member)
+
+      // Set up the Space and members:
+      _ <- inviteIntoSpace(owner, space, member)
+
+      // Build the Things:
+      _ <- ClientState.switchToUser(owner)
+      model <- makeModel("The Model", std.publication.publishableProp :=> true)
+      instanceName = "This Instance"
+      instance <- makeThing(model, instanceName)
+
+      // The member shouldn't initially be able to see the instance, since it isn't published yet:
+      _ <- checkNameIsMissingFor(instanceName, member)
+
+      // Publish it:
+      _ <- publish(instance)
+
+      // Now the member should be able to see it:
+      _ <- checkNameIsRealFor(instanceName, member)
+    }
+      yield ()
+  }
+}
+
+@Slow
+class PublicationMidTests extends MidTestBase {
+  import PublicationMidTests._
+
+  "Basic Publication Tests" should {
+    "pass" in {
+      runTest(basicPublicationTests)
+    }
+  }
+}

--- a/querki/scalajvm/test/querki/security/SecurityMidFuncs.scala
+++ b/querki/scalajvm/test/querki/security/SecurityMidFuncs.scala
@@ -1,14 +1,14 @@
 package querki.security
 
 import autowire._
-
 import querki.data._
 import querki.globals.execContext
 import querki.test.mid._
-
 import SecurityFunctions._
-
 import AllFuncs._
+import org.scalactic.source.Position
+import org.scalatest.Matchers._
+import querki.test.mid.ClientState.withUser
 
 /**
  * Not included in AllFuncs, since the functions here are relatively specialized and I don't want to pollute that
@@ -103,6 +103,23 @@ trait SecurityMidFuncs {
     }
       yield ()
   }
+
+  /**
+   * This (and the two convenience functions after it) are the easiest way to check read visibility of a particular
+   * Thing for the specified user.
+   */
+  def checkNameRealityFor(shouldBeReal: Boolean, name: String, who: TestUser)(implicit position: Position): TestOp[Unit] = {
+    for {
+      check <- withUser(who) { getThingInfo(TID(name)) }
+      _ = assert(check.isTag != shouldBeReal, s"Expected $name to be ${if (shouldBeReal) "real" else "tag"}, and it wasn't!")
+    }
+      yield ()
+  }
+  def checkNameIsRealFor(name: String, who: TestUser)(implicit position: Position)=
+    checkNameRealityFor(true, name, who)
+  def checkNameIsMissingFor(name: String, who: TestUser)(implicit position: Position) =
+    checkNameRealityFor(false, name, who)
+
 }
 
 object SecurityMidFuncs extends SecurityMidFuncs

--- a/querki/scalajvm/test/querki/security/SecurityMidTests.scala
+++ b/querki/scalajvm/test/querki/security/SecurityMidTests.scala
@@ -17,22 +17,6 @@ object SecurityMidTests {
       yield ()
   }
 
-  /**
-    * This (and the two convenience functions after it) are the easiest way to check read visibility of a particular
-    * Thing for the specified user.
-    */
-  def checkNameRealityFor(shouldBeReal: Boolean, name: String, who: TestUser)(implicit position: Position): TestOp[Unit] = {
-    for {
-      check <- withUser(who) { getThingInfo(TID(name)) }
-      _ = assert(check.isTag != shouldBeReal, s"Expected $name to be ${if (shouldBeReal) "real" else "tag"}, and it wasn't!")
-    }
-      yield ()
-  }
-  def checkNameIsRealFor(name: String, who: TestUser)(implicit position: Position)=
-    checkNameRealityFor(true, name, who)
-  def checkNameIsMissingFor(name: String, who: TestUser)(implicit position: Position) =
-    checkNameRealityFor(false, name, who)
-
   lazy val regressionTestQIbu6oeej: TestOp[Unit] = {
     val ownerName = "bu6oeej Owner"
     val owner = TestUser(ownerName)

--- a/querki/scalajvm/test/querki/test/mid/FullMidTests.scala
+++ b/querki/scalajvm/test/querki/test/mid/FullMidTests.scala
@@ -4,13 +4,11 @@ import cats._
 import cats.data._
 import cats.effect.IO
 import cats.implicits._
-
 import play.api.mvc.Session
-
 import querki.conversations.ConvMidTests
 import querki.security.SecurityMidTests
-
 import AllFuncs._
+import querki.publication.PublicationMidTests
 
 /**
  * This is the primary mid-level test suite. It wraps up tons of other tests into a single run,
@@ -35,6 +33,7 @@ class FullMidTests extends MidTestBase
           _ <- BasicMidTests.basicTests
           _ <- ConvMidTests.convTests
           _ <- SecurityMidTests.securityTests
+          _ <- PublicationMidTests.basicPublicationTests
         }
           yield ()
       }


### PR DESCRIPTION
This function does exactly the same thing that the Publish button does in the UI.

Includes at least a bit of mid-level testing to prove that it works as expected under normal circumstances.  (Also added the same test for the UI version while I was at it.)