### PR TITLE
Release 2.9.6.1: Better shopping list

### DIFF
--- a/querki/build.sbt
+++ b/querki/build.sbt
@@ -7,7 +7,7 @@ lazy val clients = Seq(querkiClient)
 lazy val scalaV = "2.11.12"
 lazy val akkaV = "2.4.18"
 lazy val enumeratumV = "1.5.3"
-lazy val appV = "2.9.5.2"
+lazy val appV = "2.9.6"
 
 lazy val sharedSrcDir = "scala"
 

--- a/querki/build.sbt
+++ b/querki/build.sbt
@@ -7,7 +7,7 @@ lazy val clients = Seq(querkiClient)
 lazy val scalaV = "2.11.12"
 lazy val akkaV = "2.4.18"
 lazy val enumeratumV = "1.5.3"
-lazy val appV = "2.9.6"
+lazy val appV = "2.9.6.1"
 
 lazy val sharedSrcDir = "scala"
 

--- a/querki/scalajs/src/main/scala/querki/display/GadgetListeners.scala
+++ b/querki/scalajs/src/main/scala/querki/display/GadgetListeners.scala
@@ -1,0 +1,67 @@
+package querki.display
+
+import org.scalajs.dom.html
+import org.querki.gadgets.Gadget
+import org.querki.jquery._
+
+/**
+ * This is similar to InputDependencies, but with a somewhat different focus. It is designed to enable one Gadget
+ * to hook itself to another, by DOM id. Requires cooperation of both sides, at least in the current design.
+ */
+trait GadgetListeners {
+  /**
+   * Registers the given Gadget based on its DOM id. This should be called *after* the Gadget is created.
+   */
+  def register[T <: html.Element](gadget: Gadget[T]): Unit
+
+  /**
+   * Registers a listener callback, that will be called when the named Gadget is registered.
+   *
+   * The callback may be called in-thread if the named Gadget is already registered.
+   */
+  def listenFor(id: String)(handler: Gadget[_] => Unit): Unit
+
+  /**
+   * Clears out all of the maps in here.
+   */
+  def clear(): Unit
+}
+
+class GadgetListenersImpl extends GadgetListeners {
+  type Listener = Gadget[_] => Unit
+
+  var registeredGadgets: Map[String, Gadget[_]] = Map.empty
+
+  var waitingListeners: Map[String, Set[Listener]] = Map.empty
+
+  def register[T <: html.Element](gadget: Gadget[T]): Unit = {
+    val elem: html.Element = gadget.elem
+    $(elem).prop("id").toOption.map { idAny =>
+      val id = idAny.asInstanceOf[String]
+      registeredGadgets += (id -> gadget)
+
+      // If anybody's waiting for this, fire them off:
+      waitingListeners.get(id).map { listeners: Set[Listener] =>
+        listeners.map(_(gadget))
+        waitingListeners -= id
+      }
+    }
+  }
+
+  def listenFor(id: String)(handler: Gadget[_] => Unit): Unit = {
+    registeredGadgets.get(id) match {
+      // We already have it, so fire the listener now:
+      case Some(gadget) => handler(gadget)
+      // Wait for it to show up later:
+      case None => {
+        val listeners = waitingListeners.get(id).getOrElse(Set.empty)
+        waitingListeners += (id -> (listeners + handler))
+      }
+    }
+  }
+
+  def clear(): Unit = {
+    registeredGadgets = Map.empty
+    waitingListeners = Map.empty
+  }
+}

--- a/querki/scalajs/src/main/scala/querki/display/input/InputGadgets.scala
+++ b/querki/scalajs/src/main/scala/querki/display/input/InputGadgets.scala
@@ -6,9 +6,9 @@ import org.scalajs.dom
 import dom.html.Element
 import org.querki.jquery._
 import org.querki.gadgets._
-
 import querki.globals._
 import querki.display.HookedGadget
+import querki.display.rx.{RxText, RxTextHolder}
 
 /**
  * Private interface, allowing InputGadgets to work with their master controller.
@@ -47,6 +47,8 @@ class InputGadgetsEcot(e:Ecology) extends ClientEcot(e) with InputGadgets with I
     Gadgets.registerGadgets(".propEditor", hookOtherPropEditor)
     Gadgets.registerSimpleGadget("._dateInput", { new DateGadget })
     Gadgets.registerSimpleGadget("._depends", { new DependentInputGadget })
+
+    Gadgets.registerSimpleGadget("._rxTextInput", { new RxTextHolder() })
   }
   
   /**

--- a/querki/scalajs/src/main/scala/querki/display/rx/RxText.scala
+++ b/querki/scalajs/src/main/scala/querki/display/rx/RxText.scala
@@ -6,9 +6,8 @@ import org.querki.jquery._
 import scalatags.JsDom.all._
 import rx._
 import org.querki.gadgets._
-
+import querki.display.HookedGadget
 import querki.globals._
-
 import querki.display.input.AutosizeFacade._
 
 /**
@@ -84,6 +83,19 @@ class RxInput(charFilter:Option[(JQueryEventObject, String) => Boolean], inputTy
 }
 
 class RxText(mods:Modifier*)(implicit e:Ecology, ctx:Ctx.Owner) extends RxInput("text", mods)
+
+class RxTextHolder()(implicit e: Ecology) extends HookedGadget[dom.html.Span](e) with EcologyMember
+{
+  lazy val Pages = interface[querki.pages.Pages]
+
+  def hook() = {
+    val childId: String = ${elem}.dataString("elemid")
+    implicit val owner = Pages.findPageFor(this).map(_.ctx).getOrElse(throw new Exception(s"Couldn't find my Page!"))
+    $(elem).append(new RxText(id:=childId).render)
+  }
+
+  def doRender() = ???
+}
 
 class RxTextArea(mods:Modifier*)(implicit val ecology:Ecology, val ctx:Ctx.Owner)
   extends RxTextBase[dom.html.TextArea]

--- a/querki/scalajs/src/main/scala/querki/display/rx/RxText.scala
+++ b/querki/scalajs/src/main/scala/querki/display/rx/RxText.scala
@@ -88,11 +88,13 @@ class RxTextHolder()(implicit e: Ecology) extends HookedGadget[dom.html.Span](e)
 {
   lazy val Pages = interface[querki.pages.Pages]
 
+  lazy val placeholderTxt: Option[String] = $(elem).data("placeholder").toOption.map(_.asInstanceOf[String])
+
   def hook() = {
     val childId: String = ${elem}.dataString("elemid")
     val page = Pages.findPageFor(this).getOrElse(throw new Exception(s"Couldn't find my Page!"))
     implicit val owner = page.ctx
-    val gadget = new RxText(id:=childId)
+    val gadget = new RxText(id := childId, placeholder := placeholderTxt.getOrElse(""))
     val field = gadget.render
     $(elem).append(field)
     // These fields largely exist to work with other gadgets, so expose them via the Page:

--- a/querki/scalajs/src/main/scala/querki/display/rx/RxText.scala
+++ b/querki/scalajs/src/main/scala/querki/display/rx/RxText.scala
@@ -90,8 +90,13 @@ class RxTextHolder()(implicit e: Ecology) extends HookedGadget[dom.html.Span](e)
 
   def hook() = {
     val childId: String = ${elem}.dataString("elemid")
-    implicit val owner = Pages.findPageFor(this).map(_.ctx).getOrElse(throw new Exception(s"Couldn't find my Page!"))
-    $(elem).append(new RxText(id:=childId).render)
+    val page = Pages.findPageFor(this).getOrElse(throw new Exception(s"Couldn't find my Page!"))
+    implicit val owner = page.ctx
+    val gadget = new RxText(id:=childId)
+    val field = gadget.render
+    $(elem).append(field)
+    // These fields largely exist to work with other gadgets, so expose them via the Page:
+    page.gadgetListeners.register(gadget)
   }
 
   def doRender() = ???

--- a/querki/scalajs/src/main/scala/querki/editing/CheckList.scala
+++ b/querki/scalajs/src/main/scala/querki/editing/CheckList.scala
@@ -22,6 +22,7 @@ import querki.display.rx.RxInput
 class CheckList(implicit e:Ecology) extends InputGadget[html.UList](e) with QuerkiUIUtils {
 
   lazy val Editing = interface[querki.editing.Editing]
+  lazy val PageManager = interface[querki.display.PageManager]
   lazy val Pages = interface[querki.pages.Pages]
 
   val std = DataAccess.std
@@ -71,7 +72,10 @@ class CheckList(implicit e:Ecology) extends InputGadget[html.UList](e) with Quer
 
     for {
       thingInfo <- Client[EditFunctions].create(modelId, Seq(msg)).call()
-      _ <- saveChange(AddToSet(path, thingInfo.oid.underlying))
+      _ <- saveChange(AddToSet(Editing.propPath(propId), thingInfo.oid.underlying))
+      // TODO: it would be better to just reload this list, a la _updateableSection, but that's not modular
+      // enough yet:
+      reloadedPage <- PageManager.reload()
     }
       StatusLine.showBriefly("Saved")
   }

--- a/querki/scalajs/src/main/scala/querki/editing/CheckList.scala
+++ b/querki/scalajs/src/main/scala/querki/editing/CheckList.scala
@@ -1,14 +1,15 @@
 package querki.editing
 
 import org.scalajs.dom.html
-
 import org.querki.jquery._
+
+import rx._
 
 import querki.display.QuerkiUIUtils
 import querki.display.input.InputGadget
 import querki.globals._
-
 import EditFunctions._
+import querki.display.rx.RxInput
 
 /**
  * The client side of the _checkList function.
@@ -20,11 +21,29 @@ import EditFunctions._
 class CheckList(implicit e:Ecology) extends InputGadget[html.UList](e) with QuerkiUIUtils {
   
   lazy val Editing = interface[querki.editing.Editing]
-  
+  lazy val Pages = interface[querki.pages.Pages]
+
   def values = ???
   def doRender() = ???
   
   lazy val propId = $(elem).tidString("prop")
+
+  // _checkList() may optionally specify a filter input and a new-item input, which may be the same thing.
+  // Either way, it should be the id of an RxInput.
+  lazy val filterId: Option[String] = $(elem).data("filterid").toOption.map(_.asInstanceOf[String])
+
+  lazy val allPicksByDisplay: Map[String, html.Element] = {
+    // Index all of the list items by their display text, so that we can filter if desired:
+    val pairs = $(elem).find("._pickName").mapElems { nameElement =>
+      val text = nameElement.textContent
+      // This .get is always a little suspicious, but it's hard to see how it could fail:
+      val parent = $(nameElement).parent().get(0).get.asInstanceOf[html.Element]
+      (text, parent)
+    }
+    pairs.toMap
+  }
+
+  var filterHook: Option[Obs] = None
   
   def saveCheckbox(checkbox:html.Element) = {
     val v = $(checkbox).valueString
@@ -43,5 +62,35 @@ class CheckList(implicit e:Ecology) extends InputGadget[html.UList](e) with Quer
       val checkbox = evt.target.asInstanceOf[html.Element]
       saveCheckbox(checkbox)
     })
+
+    // If we're filtering, connect to the filter field:
+    filterId.map { id =>
+      Pages.findPageFor(this).map { page =>
+        page.gadgetListeners.listenFor(id) { filterGadget =>
+          val rxInput = filterGadget.asInstanceOf[RxInput]
+          implicit val ctx = page.ctx
+          filterHook = Some {
+            rxInput.textOpt.trigger {
+              rxInput.textOpt.now match {
+                case Some(filterText) => {
+                  val txt = filterText.toLowerCase
+                  allPicksByDisplay.foreach { case (text, e) =>
+                    if (text.toLowerCase.contains(filterText))
+                      $(e).show()
+                    else
+                      $(e).hide()
+                  }
+                }
+                case None => {
+                  allPicksByDisplay.values.foreach { e =>
+                    $(e).show()
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
   }  
 }

--- a/querki/scalajs/src/main/scala/querki/pages/Page.scala
+++ b/querki/scalajs/src/main/scala/querki/pages/Page.scala
@@ -1,7 +1,6 @@
 package querki.pages
 
 import scala.concurrent.{Future, Promise}
-
 import org.scalajs.dom.{raw => dom}
 import scalatags.JsDom.all._
 import scalatags.JsDom.TypedTag
@@ -10,13 +9,11 @@ import org.querki.gadgets._
 import org.querki.jsext._
 import org.querki.jquery._
 import org.querki.squery.Focusable._
-
 import querki.globals._
-
 import querki.api.StandardThings
 import querki.comm._
 import querki.data.ThingInfo
-import querki.display.{ButtonGadget, SmallButtonGadget, QuerkiUIUtils, WrapperDiv}
+import querki.display.{ButtonGadget, QuerkiUIUtils, GadgetListeners, SmallButtonGadget, GadgetListenersImpl, WrapperDiv}
 import querki.display.input.{InputDependencies, InputDependenciesHandler}
   
 case class PageContents(title:String, content:TypedTag[dom.HTMLDivElement]) {  
@@ -230,4 +227,9 @@ abstract class Page(pageName:String = "")
    * up on page change.
    */
   lazy val inputDependencies: InputDependencies = new InputDependenciesHandler
+
+  /**
+   * This allows cooperating Gadgets to connect with each other.
+   */
+  lazy val gadgetListeners: GadgetListeners = new GadgetListenersImpl
 }

--- a/querki/scalajvm/app/querki/editing/EditorModule.scala
+++ b/querki/scalajvm/app/querki/editing/EditorModule.scala
@@ -427,7 +427,6 @@ class EditorModule(e:Ecology) extends QuerkiEcot(e) with Editor with querki.core
   lazy val CheckListMethod = new InternalMethod(CheckListOID,
     toProps(
       setName("_checkList"),
-      setInternal,
       Summary("""Display a checklist of items to add or remove from a Set."""),
       Signature(
         expected = Some(Seq(LinkType), "The items to choose from."),
@@ -450,9 +449,9 @@ class EditorModule(e:Ecology) extends QuerkiEcot(e) with Editor with querki.core
         |for each item that you sometimes shop for, and a Shops Tag Set saying where it can be found.
         |You have a Thing named "Shopping List", with a Property "Contents", which is a Set of Things.
         |You would display the whole shopping list, as a checklist, like this:
-        |```
-        |\[[Shopping Item._instances -> Contents.checkList(on = Shopping List)\]]
-        |```
+        |[[```
+        |[[Shopping Item._instances -> Contents.checkList(on = Shopping List)]]
+        |```]]
         |That is, the actual list is found in Shopping List.Contents, and you are choosing from
         |all Instances of Shopping Item. This lets you easily add Items to the list.
         |
@@ -466,12 +465,28 @@ class EditorModule(e:Ecology) extends QuerkiEcot(e) with Editor with querki.core
         |
         |You can filter which items show on the list. For instance, you could show a list of just the
         |Items to look for at Acme like this:
-        |```
-        |\[[Shopping Item._instances 
+        |[[```
+        |[[Shopping Item._instances
         |  -> _filter(Shops -> _contains(Acme))
-        |  -> Contents._checkList(on = Shopping List, selectedOnly = true)\]]
-        |```
+        |  -> Contents._checkList(on = Shopping List, selectedOnly = true)]]
+        |```]]
         |This way, you can easily display customized checklists for particular situations.
+        |
+        |You can also create a live filter-by-name. If you specify the `filterField` parameter, that should point
+        |to a _textInput that you can type into, to filter down the items being currently shown in the checklist.
+        |
+        |You can also use the `filterField` to add new items. If you add the `addModel` parameter, that specifies
+        |the model for the items in this list; if you type in a new name in the `filterField` and press Enter, a
+        |new instance of that model will be created, with the given name, and added to the checklist.
+        |
+        |So putting those together, you can specify a full shopping list, that lets you filter the items being
+        |shown and add new one on the fly, like this:
+        |[[```
+        |[[_textInput(id = ""itemfilter"", placeholder = ""Filter or add items"")]]
+        |
+        |[[Shopping Item._instances ->
+        |  Shopping Items._checkList(on = Shopping List, filterField = ""itemfilter"", addModel = Shopping Item)]]
+        |```]]
         |
         |By default, _checkList will display show each item's Name. But you can customize this using
         |the `display` parameter. If provided, this will be applied to every item, and the result is

--- a/querki/scalajvm/app/querki/editing/EditorModule.scala
+++ b/querki/scalajvm/app/querki/editing/EditorModule.scala
@@ -438,7 +438,8 @@ class EditorModule(e:Ecology) extends QuerkiEcot(e) with Editor with querki.core
         opts = Seq(
           ("selectedOnly", YesNoType, ExactlyOne(Logic.False), "If True, only items currently in the Set will be displayed."),
           ("display", AnyType, Core.QNone, "How to display each item."),
-          ("filterField", TextType, Core.QNone, "If specified, the ID of a text field to filter on")
+          ("filterField", TextType, Core.QNone, "If specified, the ID of a text field to filter on"),
+          ("addModel", LinkType, Core.QNone, "If specified, you can type names in the `filterField`, and new Instances of this Model will be created")
         ),
         returns = (AnyType, "The Check List, ready to display.")
       ),
@@ -483,6 +484,7 @@ class EditorModule(e:Ecology) extends QuerkiEcot(e) with Editor with querki.core
         selectedOnly <- inv.processAs("selectedOnly", YesNoType)
         setOID <- inv.processAs("on", LinkType)
         filterField <- inv.processAsOpt("filterField", TextType)
+        modelOIDOpt <- inv.processAsOpt("addModel", LinkType)
         setThing <- inv.opt(state.anything(setOID))
         setProp <- inv.definingContextAsPropertyOf(LinkType)
         currentPV <- inv.opt(setThing.getPropOpt(setProp), Some(new PublicException("Edit.checklist.propMissing", setThing.displayName, setProp.displayName)))
@@ -498,6 +500,8 @@ class EditorModule(e:Ecology) extends QuerkiEcot(e) with Editor with querki.core
               // Note that scalatags is one of the few contexts where an imbalanced if is legit:
               if (filterField.isDefined)
                 data.filterid:=filterField.get.text,
+              if (modelOIDOpt.isDefined)
+                data.modelid:=modelOIDOpt.get.toThingId.toString,
               ul(
                 cls:="_listContent",
                 raw(itemStr)

--- a/querki/scalajvm/app/querki/editing/EditorModule.scala
+++ b/querki/scalajvm/app/querki/editing/EditorModule.scala
@@ -437,7 +437,8 @@ class EditorModule(e:Ecology) extends QuerkiEcot(e) with Editor with querki.core
         ),
         opts = Seq(
           ("selectedOnly", YesNoType, ExactlyOne(Logic.False), "If True, only items currently in the Set will be displayed."),
-          ("display", AnyType, Core.QNone, "How to display each item.")
+          ("display", AnyType, Core.QNone, "How to display each item."),
+          ("filterField", TextType, Core.QNone, "If specified, the ID of a text field to filter on")
         ),
         returns = (AnyType, "The Check List, ready to display.")
       ),
@@ -481,6 +482,7 @@ class EditorModule(e:Ecology) extends QuerkiEcot(e) with Editor with querki.core
       for {
         selectedOnly <- inv.processAs("selectedOnly", YesNoType)
         setOID <- inv.processAs("on", LinkType)
+        filterField <- inv.processAsOpt("filterField", TextType)
         setThing <- inv.opt(state.anything(setOID))
         setProp <- inv.definingContextAsPropertyOf(LinkType)
         currentPV <- inv.opt(setThing.getPropOpt(setProp), Some(new PublicException("Edit.checklist.propMissing", setThing.displayName, setProp.displayName)))
@@ -493,6 +495,9 @@ class EditorModule(e:Ecology) extends QuerkiEcot(e) with Editor with querki.core
               cls:="_checklist",
               data.thing:=setThing.id.toThingId.toString,
               data.prop:=setProp.id.toThingId.toString,
+              // Note that scalatags is one of the few contexts where an imbalanced if is legit:
+              if (filterField.isDefined)
+                data.filterid:=filterField.get.text,
               ul(
                 cls:="_listContent",
                 raw(itemStr)

--- a/querki/scalajvm/app/querki/html/UIModule.scala
+++ b/querki/scalajvm/app/querki/html/UIModule.scala
@@ -1043,7 +1043,16 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
         opts = Seq(
           ("placeholder", TextType, Core.QNone, "Some placeholder text to display when the field is empty")
         )
-      )
+      ),
+      Details(
+        """
+          |This is similar to [[_QLInput._self]], and might eventually be merged with it, but has a different purpose.
+          |`_textInput` is designed for live interaction within a page: it is a text field that can work with other
+          |controls to make things happen as the user types into it.
+          |
+          |For example, this works with the [[_checkList._self]] function, letting you filter the checklist items
+          |being displayed, or add new ones.
+          |""".stripMargin)
     ))
   {
     override def qlApply(inv: Invocation) = {

--- a/querki/scalajvm/app/querki/html/UIModule.scala
+++ b/querki/scalajvm/app/querki/html/UIModule.scala
@@ -1039,6 +1039,9 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
       Signature(
         reqs = Seq(
           ("id", TextType, "The id of this field, which should be unique on this page")
+        ),
+        opts = Seq(
+          ("placeholder", TextType, Core.QNone, "Some placeholder text to display when the field is empty")
         )
       )
     ))
@@ -1046,11 +1049,14 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
     override def qlApply(inv: Invocation) = {
       for {
         idStr <- inv.processAs("id", TextType)
+        placeholderTxt <- inv.processAsOpt("placeholder", TextType)
       }
         yield HtmlValue(
           span(
             cls := "_rxTextInput",
-            data.elemid := idStr.text
+            data.elemid := idStr.text,
+            if (placeholderTxt.isDefined)
+              data.placeholder := placeholderTxt.get.text
           )
         )
     }

--- a/querki/scalajvm/app/querki/html/UIModule.scala
+++ b/querki/scalajvm/app/querki/html/UIModule.scala
@@ -879,7 +879,7 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
           ("contents", AnyType, "The contents of this section")
         ),
         opts = Seq.empty,
-        returns = (RawHtmlType, "The rendered section, which can be updated by calling `_updateSection` from inside.")
+        returns = (RawHtmlType, "The rendered section, which can be updated by setting `_updateSectionAfter` on a QLButton, QLLink or QLInput inside it.")
       )))
   {
     override def qlApply(inv: Invocation): QFut = {

--- a/querki/scalajvm/app/querki/html/UIModule.scala
+++ b/querki/scalajvm/app/querki/html/UIModule.scala
@@ -41,6 +41,7 @@ object UIMOIDs extends EcotIds(11) {
   val UniqueHtmlIdOID = moid(13)
   val UpdateableSectionOID = moid(14)
   val UpdateSectionOID = moid(15)
+  val TextInputOID = moid(16)
 }
 
 /**
@@ -1029,6 +1030,31 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
       fut(QL.WikitextValue(models.Wikitext(s"_rndid${n.toString}")))
     }
   }
+
+  lazy val TextInputMethod = new InternalMethod(TextInputOID,
+    toProps(
+      setName("_textInput"),
+      Categories(UITag),
+      Summary("Displays a text input field, which can be used by other displays like `_checkList`"),
+      Signature(
+        reqs = Seq(
+          ("id", TextType, "The id of this field, which should be unique on this page")
+        )
+      )
+    ))
+  {
+    override def qlApply(inv: Invocation) = {
+      for {
+        idStr <- inv.processAs("id", TextType)
+      }
+        yield HtmlValue(
+          span(
+            cls := "_rxTextInput",
+            data.elemid := idStr.text
+          )
+        )
+    }
+  }
   
   override lazy val props = Seq(
     classMethod,
@@ -1051,6 +1077,7 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
     ShowSomeFunction,
     MenuButton,
     UniqueHtmlId,
-    UpdateableSection
+    UpdateableSection,
+    TextInputMethod
   )
 }

--- a/querki/scalajvm/app/querki/ql/package.scala
+++ b/querki/scalajvm/app/querki/ql/package.scala
@@ -470,10 +470,10 @@ package object ql {
      *   not use the defining context, leave this as None.
      */
     def apply(
-      expected:Option[(Seq[PType[_]], String)], 
-      reqs:Seq[(String, PType[_], String)], 
-      opts:Seq[(String, PType[_], QValue, String)], 
-      returns:(PType[_], String),
+      expected:Option[(Seq[PType[_]], String)] = None,
+      reqs:Seq[(String, PType[_], String)] = Seq.empty,
+      opts:Seq[(String, PType[_], QValue, String)] = Seq.empty,
+      returns:(PType[_], String) = (AnyType, ""),
       defining:Option[(Boolean, Seq[PType[_]], String)] = None
     ):(OID, QValue)
   }


### PR DESCRIPTION
(Note that there was no Release 2.9.6, because I realized I had forgotten the documentation.)

This introduces two new functions that produce UI controls.

On the one hand, there is `_textInput`.  This displays an input field, similar to `_QLInput` but with a different purpose: whereas `_QLInput` lets you input something and then runs some QL when you press Enter, this lets you enter some text solely for the benefit of other controls on the page.

This is used by the new `_checkList` function, which replaces the old `_editAsPickList`.  They have similar purposes: they display a Set as a checklist, so that you can edit the Set by checking boxes, but is much better-structured, and considerably more powerful.  By combining it with `_textInput` you get all the capabilities of the old `_editAsPickList`, plus live filtering of the list.  (Which can make it much easier to work with large Sets -- the motivation here was that I found that managing a Shopping List using the old system was way too much hassle.)

I expect that we will find more uses for `_textInput` -- feel free to suggest ways in which it might be helpful.