### PR TITLE
QI.7w4ger9, QI.7w4gerb -- add _listDeletedThings()

### DIFF
--- a/querki/.scalafmt.conf
+++ b/querki/.scalafmt.conf
@@ -1,17 +1,28 @@
-version = "2.0.0"
+version = "2.7.5"
 project {
   git = true
 }
-align = "none"
+align {
+  stripMargin = true
+}
 maxColumn = 120
+comments {
+  wrapStandaloneSlcAsSlc = true
+}
+docstrings {
+  style = Asterisk
+  oneline = unfold
+}
 continuationIndent {
   defnSite = 2
   extendSite = 2
+  withSiteRelativeToExtends = 3
 }
 assumeStandardLibraryStripMargin = true
 newlines {
   alwaysBeforeTopLevelStatements = true
   sometimesBeforeColonInMethodReturnType = false
+  source = keep
 }
 verticalMultiline {
   arityThreshold = 2
@@ -25,8 +36,6 @@ rewrite {
   rules = [
     "AvoidInfix"
     "PreferCurlyFors"
-    "RedundantBraces"
-    "RedundantParens"
     "SortImports"
     "SortModifiers"
   ]
@@ -47,6 +56,6 @@ rewrite {
   }
 }
 spaces {
-  beforeContextBoundColon = true
+  beforeContextBoundColon = Always
 }
 trailingCommas = "preserve"

--- a/querki/scalajs/src/main/scala/querki/pages/AdvancedPage.scala
+++ b/querki/scalajs/src/main/scala/querki/pages/AdvancedPage.scala
@@ -14,123 +14,135 @@ import querki.display.{ButtonGadget, Dialog, QText}
 import querki.globals._
 import querki.security.SecurityFunctions
 
-class AdvancedPage(params:ParamMap)(implicit val ecology:Ecology) extends Page("advancedCommands") {
+class AdvancedPage(params: ParamMap)(implicit val ecology: Ecology) extends Page("advancedCommands") {
   lazy val thingId = TID(params("thingId"))
-  
+
   lazy val Apps = interface[querki.apps.Apps]
   lazy val Client = interface[querki.client.Client]
   lazy val Console = interface[querki.console.Console]
   lazy val History = interface[querki.history.History]
   lazy val StatusLine = interface[querki.display.StatusLine]
-  
+
   lazy val canManageData = DataAccess.space.map { space =>
     space.permissions.contains(std.security.canManageDataPerm.oid)
   }.getOrElse(false)
 
-  def archiveAfterConfirm(info:SpaceInfo) = {
-    val archiveDialog:Dialog = 
-      new Dialog("Confirm Archive",
-        p(b(s"Are you sure you want to archive the entire Space ${info.displayName}? It may be a number of months before you can retrieve it!")),
-        (ButtonGadget.Danger, Seq("Archive", id := "_archiveConfirm"), { dialog => 
-          // TODO: display a spinner
-          Client[SecurityFunctions].archiveThisSpace().call().onComplete { 
-            case Success(b) if (b == true) => {
-              // This Space has been archived, so we're no longer allowed to call it. Navigate to index, since that's
-              // pretty much the only thing we can do:
-              PageManager.showIndexPage()
-            }
-            case Failure(ex) => {
-              ex match {
-                case CanNotArchiveException() => StatusLine.showUntilChange("You are not allowed to archive this Space!")
-                case _ => StatusLine.showUntilChange(ex.toString())
+  def archiveAfterConfirm(info: SpaceInfo) = {
+    val archiveDialog: Dialog =
+      new Dialog(
+        "Confirm Archive",
+        p(b(
+          s"Are you sure you want to archive the entire Space ${info.displayName}? It may be a number of months before you can retrieve it!"
+        )),
+        (
+          ButtonGadget.Danger,
+          Seq("Archive", id := "_archiveConfirm"),
+          { dialog =>
+            // TODO: display a spinner
+            Client[SecurityFunctions].archiveThisSpace().call().onComplete {
+              case Success(b) if (b == true) => {
+                // This Space has been archived, so we're no longer allowed to call it. Navigate to index, since that's
+                // pretty much the only thing we can do:
+                PageManager.showIndexPage()
+              }
+              case Failure(ex) => {
+                ex match {
+                  case CanNotArchiveException() =>
+                    StatusLine.showUntilChange("You are not allowed to archive this Space!")
+                  case _ => StatusLine.showUntilChange(ex.toString())
+                }
               }
             }
           }
-        }),
+        ),
         (ButtonGadget.Normal, Seq("Cancel", id := "_archiveCancel"), { dialog => dialog.done() })
       )
     archiveDialog.show()
   }
-  
+
   val ql =
     s"""""### Advanced commands for ____
-        |
-        |Currently running on *[[_clusterAddress]]*
-        |
-        |[[_if(_isModel,
-        |""**[Export all Instances of [[Link Name]] as a CSV file](_exportModel?modelId=[[_oid]]&format=1)**""
-        |)]]
-        |
-        |[[_orphanedInstances -> _section(""### Orphaned Instances"", 
-        |""These Instances belong to missing Models; we recommend going into each one, opening Advanced Edit from the
-        |Actions menu, and changing their Model.
-        |
-        |[[_bulleted]]
-        |
-        |------"")]]
-        |
-        |[[_if(_hasPermission(Who Can Read Comments._self), 
-        |  ""**Send me a Message whenever someone comments in this Space:** [[_space -> _getCommentNotifications._edit]]
-        |("Maybe" means the default: Yes if you are the owner of this space, No otherwise.)
-        |**Note:** this may not take effect for a few hours."")]]""""".stripMargin
-        
+       |
+       |Currently running on *[[_clusterAddress]]*
+       |
+       |[[_if(_isModel,
+       |""**[Export all Instances of [[Link Name]] as a CSV file](_exportModel?modelId=[[_oid]]&format=1)**""
+       |)]]
+       |
+       |[[_orphanedInstances -> _section(""### Orphaned Instances"", 
+       |""These Instances belong to missing Models; we recommend going into each one, opening Advanced Edit from the
+       |Actions menu, and changing their Model.
+       |
+       |[[_bulleted]]
+       |
+       |------"")]]
+       |
+       |[[_if(_hasPermission(Who Can Read Comments._self), 
+       |  ""**Send me a Message whenever someone comments in this Space:** [[_space -> _getCommentNotifications._edit]]
+       |("Maybe" means the default: Yes if you are the owner of this space, No otherwise.)
+       |**Note:** this may not take effect for a few hours."")]]""""".stripMargin
+
   val exportedXML = GadgetRef.of[dom.html.Div]
 
   def pageContent = for {
     gutsRaw <- Client[ThingFunctions].evaluateQL(thingId, ql).call()
-    guts = 
+    guts =
       div(
         new QText(gutsRaw),
         div(
           p("""Press this button to open the Querki Console. This is a "command line" interface, that provides a
               |few power-user features that are rarely needed."""),
-          new ButtonGadget(ButtonGadget.Info, "Open Console", id := "_consoleButton") ({ () =>
+          new ButtonGadget(ButtonGadget.Info, "Open Console", id := "_consoleButton")({ () =>
             Console.consoleFactory.showPage()
           })
         ),
         if (canManageData) {
           div(
             p("""Press this button to reload this Space. (This is mainly for testing; you can usually ignore it.)"""),
-            new ButtonGadget(ButtonGadget.Info, "Reload", id := "_reloadButton") ({ () =>
+            new ButtonGadget(ButtonGadget.Info, "Reload", id := "_reloadButton")({ () =>
               Client[ThingFunctions].reloadSpace().call().foreach { _ =>
                 PageManager.reload().map { _ =>
                   StatusLine.showUntilChange("Reloaded")
                 }
               }
             }),
-            
+            //
             p("""Press this button to view the history of this Space"""),
-            new ButtonGadget(ButtonGadget.Info, "View History", id := "_historyButton") ({ () =>
+            new ButtonGadget(ButtonGadget.Info, "View History", id := "_historyButton")({ () =>
               History.historySummaryFactory.showPage()
             }),
-              
+            //
             p("""Press this button to export this *entire* Space as XML. (NOTE: photographs are not exported.)
               The exported XML will open in a new tab or window, which you can save if you want."""),
             a(
-              cls:="btn btn-default",
-              target:="_blank",
-              href:="_export.xml",
+              cls := "btn btn-default",
+              target := "_blank",
+              href := "_export.xml",
               "Export Space to XML"
-            )
+            ),
+            //
+            p(
+              """Press this button to view all Things that have been deleted in this Space, and restore them if desired"""
+            ),
+            new ButtonGadget(ButtonGadget.Info, "Show Deleted Things", id := "_showDeletedThingsButton")({ () =>
+              PageManager.navigateTo(thingUrl(TID("System-Deleted-Things-Page")))
+            })
           )
         },
-          
         // Archiving is one of the few functions that Managers can *not* do:
         if (DataAccess.request.isOwner) {
           div(
             p("""Press this button to Archive this Space. NOTE: there is currently no way to list or recover Archived
               Spaces! Those capabilities are at least a few months away, so only Archive this Space if you are sure
               you aren't going to need it any time soon!"""),
-            new ButtonGadget(ButtonGadget.Danger, "Archive this Space") ({ () =>
+            new ButtonGadget(ButtonGadget.Danger, "Archive this Space")({ () =>
               archiveAfterConfirm(DataAccess.space.get)
             })
           )
         },
-        
-        new ButtonGadget(ButtonGadget.Primary, "Done")({ () => 
+        new ButtonGadget(ButtonGadget.Primary, "Done")({ () =>
           Pages.thingPageFactory.showPage(thingId)
         })
       )
-  }
-    yield PageContents(pageTitle, guts)
+  } yield PageContents(pageTitle, guts)
 }

--- a/querki/scalajvm/app/querki/collections/CollectionsModule.scala
+++ b/querki/scalajvm/app/querki/collections/CollectionsModule.scala
@@ -18,7 +18,7 @@ object MOIDs extends EcotIds(6) {
   val CountMethodOID = sysId(87)
   val ReverseMethodOID = sysId(88)
   val DescMethodOID = sysId(89)
-  
+
   val PrevInListOID = moid(1)
   val NextInListOID = moid(2)
   val ForeachMethodOID = moid(3)
@@ -32,233 +32,260 @@ object MOIDs extends EcotIds(6) {
   val PositionsMethodOID = moid(11)
 }
 
-class CollectionsModule(e:Ecology) extends QuerkiEcot(e) with querki.core.MethodDefs with querki.logic.YesNoUtils with Collections {
+class CollectionsModule(e: Ecology)
+  extends QuerkiEcot(e)
+     with querki.core.MethodDefs
+     with querki.logic.YesNoUtils
+     with Collections {
   import MOIDs._
 
   lazy val Basic = interface[querki.basic.Basic]
   lazy val Logic = interface[querki.logic.Logic]
   lazy val QL = interface[querki.ql.QL]
-  
+
   lazy val PlainTextType = Basic.PlainTextType
-  
-  /***********************************************
+
+  /**
+   * *********************************************
    * FUNCTIONS
-   ***********************************************/
-  
-  lazy val FirstMethod = new InternalMethod(FirstMethodOID,
-      toProps(
-        setName("_first"),
-        Summary("""Grabs just the first thing from the received context."""),
-        Categories(CollTag),
-        Signature(
-          expected = Some(Seq(AnyType), "A List of anything"),
-          reqs = Seq.empty,
-          opts = Seq.empty,
-          returns = (AnyType, "The first element in the received list, or None if it was empty.")
-        ),
-        Details("""Often you have a List, and you just want the first item in the List. (Especially when you
-            |expect the list to only have one element in it.) Use _first to turn that List into an
-            |Optional instead.""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+   * *********************************************
+   */
+
+  lazy val FirstMethod = new InternalMethod(
+    FirstMethodOID,
+    toProps(
+      setName("_first"),
+      Summary("""Grabs just the first thing from the received context."""),
+      Categories(CollTag),
+      Signature(
+        expected = Some(Seq(AnyType), "A List of anything"),
+        reqs = Seq.empty,
+        opts = Seq.empty,
+        returns = (AnyType, "The first element in the received list, or None if it was empty.")
+      ),
+      Details("""Often you have a List, and you just want the first item in the List. (Especially when you
+                |expect the list to only have one element in it.) Use _first to turn that List into an
+                |Optional instead.""".stripMargin)
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       val context = inv.context
-      
+
       val sourceColl = context.value
-      val result = 
+      val result =
         if (sourceColl.isEmpty)
           Core.emptyOpt(sourceColl.pType)
         else
           Optional(sourceColl.cv.head)
-          
+
       Future.successful(result)
-    }
-  }
-  
-  lazy val RestMethod = new InternalMethod(RestMethodOID,
-      toProps(
-        setName("_rest"),
-        Categories(CollTag),
-        Summary("""Produces everything but the first thing from the received context."""),
-        Signature(
-          expected = Some(Seq.empty, "A List of anything"),
-          reqs = Seq.empty,
-          opts = Seq.empty,
-          returns = (AnyType, "The List of everything except the first element, or None if the received List had fewer than two elements in it.")
-        ),
-        Details("""Often you have a List, and you want to slice off the first item (using _first). You then use _rest
-            |to handle everything else.""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
-      val context = inv.context
-      
-      val sourceColl = context.value
-      val result = if (sourceColl.isEmpty)
-        // Cut processing at this point:
-        // TODO: can/should we preserve the source PType?
-        QL.EmptyListCut()
-      else
-        QList.makePropValue(sourceColl.cv.tail.toList, context.value.pType)
-        
-      Future.successful(result)
-    }
-  }
-  
-  lazy val TakeMethod = new InternalMethod(TakeOID,
-      toProps(
-        setName("_take"),
-        Categories(CollTag),
-        Summary("""Produces the first N values from the received context."""),
-        Signature(
-          expected = Some(Seq.empty, "A List of anything"),
-          reqs = Seq(
-            ("howMany", IntType, "The number of elements to take from the beginning of the List")
-          ),
-          opts = Seq.empty,
-          returns = (AnyType, "The first *howMany* elements, if the received List had that many, or the full received List if not.")
-        ),
-        Details("""Sometimes you want just the first few elements of a List. _take does that -- think of
-            |it as taking the beginning of the List, and leaving the rest behind.
-            |
-            |Note that `_first` is basically the same as `_take(1)`.""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
-      for {
-        n <- inv.processAs("howMany", IntType)
-        qv <- inv.contextValue
-      }
-        yield QList.makePropValue(qv.cv.take(n), inv.context.value.pType)
-    }
-  }
-  
-  lazy val DropMethod = new InternalMethod(DropOID,
-      toProps(
-        setName("_drop"),
-        Categories(CollTag),
-        Summary("""Produces all but the first N values from the received context."""),
-        Signature(
-          expected = Some(Seq.empty, "A List of anything"),
-          reqs = Seq(
-            ("howMany", IntType, "The number of elements to drop from the beginning of the List")
-          ),
-          opts = Seq.empty,
-          returns = (AnyType, "The rest of the List after dropping the first *howMany* elements")
-        ),
-        Details("""_drop is the inverse of _take -- it drops the first *howMany*, and produces what's left,
-            |if anything.
-            |
-            |Note that _rest is roughly the same as _drop(1).""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
-      for {
-        n <- inv.processAs("howMany", IntType)
-        qv <- inv.contextValue
-      }
-        yield QList.makePropValue(qv.cv.drop(n), inv.context.value.pType)
     }
   }
 
-  def isEmpty(inv:Invocation):Future[Boolean] = {
+  lazy val RestMethod = new InternalMethod(
+    RestMethodOID,
+    toProps(
+      setName("_rest"),
+      Categories(CollTag),
+      Summary("""Produces everything but the first thing from the received context."""),
+      Signature(
+        expected = Some(Seq.empty, "A List of anything"),
+        reqs = Seq.empty,
+        opts = Seq.empty,
+        returns = (
+          AnyType,
+          "The List of everything except the first element, or None if the received List had fewer than two elements in it."
+        )
+      ),
+      Details("""Often you have a List, and you want to slice off the first item (using _first). You then use _rest
+                |to handle everything else.""".stripMargin)
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
+      val context = inv.context
+
+      val sourceColl = context.value
+      val result =
+        if (sourceColl.isEmpty)
+          // Cut processing at this point:
+          // TODO: can/should we preserve the source PType?
+          QL.EmptyListCut()
+        else
+          QList.makePropValue(sourceColl.cv.tail.toList, context.value.pType)
+
+      Future.successful(result)
+    }
+  }
+
+  lazy val TakeMethod = new InternalMethod(
+    TakeOID,
+    toProps(
+      setName("_take"),
+      Categories(CollTag),
+      Summary("""Produces the first N values from the received context."""),
+      Signature(
+        expected = Some(Seq.empty, "A List of anything"),
+        reqs = Seq(
+          ("howMany", IntType, "The number of elements to take from the beginning of the List")
+        ),
+        opts = Seq.empty,
+        returns = (
+          AnyType,
+          "The first *howMany* elements, if the received List had that many, or the full received List if not."
+        )
+      ),
+      Details("""Sometimes you want just the first few elements of a List. _take does that -- think of
+                |it as taking the beginning of the List, and leaving the rest behind.
+                |
+                |Note that `_first` is basically the same as `_take(1)`.""".stripMargin)
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
+      for {
+        n <- inv.processAs("howMany", IntType)
+        qv <- inv.contextValue
+      } yield QList.makePropValue(qv.cv.take(n), inv.context.value.pType)
+    }
+  }
+
+  lazy val DropMethod = new InternalMethod(
+    DropOID,
+    toProps(
+      setName("_drop"),
+      Categories(CollTag),
+      Summary("""Produces all but the first N values from the received context."""),
+      Signature(
+        expected = Some(Seq.empty, "A List of anything"),
+        reqs = Seq(
+          ("howMany", IntType, "The number of elements to drop from the beginning of the List")
+        ),
+        opts = Seq.empty,
+        returns = (AnyType, "The rest of the List after dropping the first *howMany* elements")
+      ),
+      Details("""_drop is the inverse of _take -- it drops the first *howMany*, and produces what's left,
+                |if anything.
+                |
+                |Note that _rest is roughly the same as _drop(1).""".stripMargin)
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
+      for {
+        n <- inv.processAs("howMany", IntType)
+        qv <- inv.contextValue
+      } yield QList.makePropValue(qv.cv.drop(n), inv.context.value.pType)
+    }
+  }
+
+  def isEmpty(inv: Invocation): Future[Boolean] = {
     val result = for {
       thing <- inv.contextAllThings
       prop <- inv.definingContextAsProperty
       propAndVal <- inv.opt(thing.localProp(prop))
-    }
-      yield propAndVal.isEmpty
-      
+    } yield propAndVal.isEmpty
+
     result.get.map(r => r.isEmpty || r.head)
   }
-  
+
   /**
    * TBD: is this the correct definition of _isEmpty and _isNonEmpty? It feels slightly off to me, to have it specifically depend
    * on the instance like this. But otherwise, we have problems because a property is essentially *always* non-Empty if it if defined,
    * due to defaults.
-   * 
+   *
    * Maybe the correct solution is a little more nuanced, that a property is considered "empty" if its value is the default?
    */
-  lazy val IsNonEmptyMethod = new InternalMethod(IsNonEmptyOID,
-      toProps(
-        setName("_isNonEmpty"),
-        Categories(CollTag),
-        Summary("Tests whether the provided value is non-empty"),
-        Signature(
-          expected = Some(Seq.empty, "A Thing, or a List"),
-          reqs = Seq.empty,
-          opts = Seq(
-            ("exp", AnyType, Core.QNone, "An expression to apply to the received value")
-          ),
-          returns = (YesNoType, "Yes if the list has anything in it; No if it is empty"),
-          defining = Some(false, Seq(LinkType), "The Property to check whether its value is empty")
+  lazy val IsNonEmptyMethod = new InternalMethod(
+    IsNonEmptyOID,
+    toProps(
+      setName("_isNonEmpty"),
+      Categories(CollTag),
+      Summary("Tests whether the provided value is non-empty"),
+      Signature(
+        expected = Some(Seq.empty, "A Thing, or a List"),
+        reqs = Seq.empty,
+        opts = Seq(
+          ("exp", AnyType, Core.QNone, "An expression to apply to the received value")
         ),
-        Details("""There are several different versions of _isNonEmpty, depending on what you want to test:
-            |```
-            |Thing -> Property._isNonEmpty
-            |```
-            |Given a *Thing*, this checks whether it has *Property* and its value is not empty.
-            |```
-            |List -> _isNonEmpty
-            |```
-            |Given a received List of any sort, this checks whether that List is not empty.
-            |```
-            |Anything -> _isNonEmpty(exp)
-            |```
-            |This is the most general form -- it applies *exp* to the received value, and checks whether
-            |the result is empty. For example, if you have a Bookcase, and want to check whether any of the
-            |Books on it were about Politics, it might look like:
-            |```
-            |My Bookcase -> _isNonEmpty(Books -> _filter(Topic -> _is(Politics)))
-            |```
-            |""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+        returns = (YesNoType, "Yes if the list has anything in it; No if it is empty"),
+        defining = Some(false, Seq(LinkType), "The Property to check whether its value is empty")
+      ),
+      Details("""There are several different versions of _isNonEmpty, depending on what you want to test:
+                |```
+                |Thing -> Property._isNonEmpty
+                |```
+                |Given a *Thing*, this checks whether it has *Property* and its value is not empty.
+                |```
+                |List -> _isNonEmpty
+                |```
+                |Given a received List of any sort, this checks whether that List is not empty.
+                |```
+                |Anything -> _isNonEmpty(exp)
+                |```
+                |This is the most general form -- it applies *exp* to the received value, and checks whether
+                |the result is empty. For example, if you have a Bookcase, and want to check whether any of the
+                |Books on it were about Politics, it might look like:
+                |```
+                |My Bookcase -> _isNonEmpty(Books -> _filter(Topic -> _is(Politics)))
+                |```
+                |""".stripMargin)
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       if (inv.definingContext.isDefined)
         isEmpty(inv).map(v => boolean2YesNoQValue(!v))
-      else 
+      else
         for {
           raw <- inv.rawParam("exp")
           v <- raw match {
             case Some(_) => inv.process("exp")
-            case _ => inv.contextValue
+            case _       => inv.contextValue
           }
-        }
-          yield boolean2YesNoQValue(!v.isEmpty)
+        } yield boolean2YesNoQValue(!v.isEmpty)
     }
   }
-  
-  lazy val IsEmptyMethod = new InternalMethod(IsEmptyOID,
-      toProps(
-        setName("_isEmpty"),
-        Categories(CollTag),
-        Summary("Tests whether the provided value is empty"),
-        Signature(
-          expected = Some(Seq.empty, "A Thing, or a List"),
-          reqs = Seq.empty,
-          opts = Seq(
-            ("exp", AnyType, Core.QNone, "An expression to apply to the received value")
-          ),
-          returns = (YesNoType, "No if the list has anything in it; Yes if it is empty"),
-          defining = Some(false, Seq(LinkType), "The Property to check whether its value is empty")
+
+  lazy val IsEmptyMethod = new InternalMethod(
+    IsEmptyOID,
+    toProps(
+      setName("_isEmpty"),
+      Categories(CollTag),
+      Summary("Tests whether the provided value is empty"),
+      Signature(
+        expected = Some(Seq.empty, "A Thing, or a List"),
+        reqs = Seq.empty,
+        opts = Seq(
+          ("exp", AnyType, Core.QNone, "An expression to apply to the received value")
         ),
-        Details("""There are several different versions of _isEmpty, depending on what you want to test:
-            |```
-            |Thing -> Property._isEmpty
-            |```
-            |Given a *Thing*, this checks whether it has *Property* and its value is empty.
-            |```
-            |List -> _isEmpty
-            |```
-            |Given a received List of any sort, this checks whether that List is empty.
-            |```
-            |Anything -> _isEmpty(exp)
-            |```
-            |This is the most general form -- it applies *exp* to the received value, and checks whether
-            |the result is empty. For example, if you have a Bookcase, and want to check whether it is
-            |empty of Books, you might say:
-            |```
-            |My Bookcase -> _isEmpty(Books)
-            |```
-            |""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+        returns = (YesNoType, "No if the list has anything in it; Yes if it is empty"),
+        defining = Some(false, Seq(LinkType), "The Property to check whether its value is empty")
+      ),
+      Details("""There are several different versions of _isEmpty, depending on what you want to test:
+                |```
+                |Thing -> Property._isEmpty
+                |```
+                |Given a *Thing*, this checks whether it has *Property* and its value is empty.
+                |```
+                |List -> _isEmpty
+                |```
+                |Given a received List of any sort, this checks whether that List is empty.
+                |```
+                |Anything -> _isEmpty(exp)
+                |```
+                |This is the most general form -- it applies *exp* to the received value, and checks whether
+                |the result is empty. For example, if you have a Bookcase, and want to check whether it is
+                |empty of Books, you might say:
+                |```
+                |My Bookcase -> _isEmpty(Books)
+                |```
+                |""".stripMargin)
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       if (inv.definingContext.isDefined)
         isEmpty(inv).map(v => boolean2YesNoQValue(v))
       else
@@ -266,116 +293,138 @@ class CollectionsModule(e:Ecology) extends QuerkiEcot(e) with querki.core.Method
           raw <- inv.rawParam("exp")
           v <- raw match {
             case Some(_) => inv.process("exp")
-            case _ => inv.contextValue
+            case _       => inv.contextValue
           }
-        }
-            yield boolean2YesNoQValue(v.isEmpty)
+        } yield boolean2YesNoQValue(v.isEmpty)
     }
   }
-  
-  lazy val FilterMethod = new InternalMethod(FilterOID,
-      toProps(
-        setName("_filter"),
-        Categories(CollTag),
-        Summary("Remove non-matching elements of a collection"),
-        Signature(
-          expected = Some(Seq.empty, "A List of any sort"),
-          reqs = Seq(("exp", YesNoType, "An expression to apply to the received value, which should produce True or False")),
-          opts = Seq.empty,
-          returns = (AnyType, "The elements of the List for which *exp* produced True")
-        ),
-        Details("""This function is how you take a List of things, and whittle them down to just the ones you want.
-            |
-            |*exp* should take one element from the received List, and produce a YesNo that says whether to include this Thing.
-            |That gets applied to each element of the List; if *exp* returns Yes, then it is included, otherwise not.
-            |
-            |IMPORTANT: if *exp*'s result is empty for one of the elements, it is considered to be No -- the element
-            |will be left out of the results.
-            |
-            |This is one of the most commonly-useful functions in Querki. It is how you usually say, "I only want *some*
-            |of the elements in this List or Set".""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+
+  lazy val FilterMethod = new InternalMethod(
+    FilterOID,
+    toProps(
+      setName("_filter"),
+      Categories(CollTag),
+      Summary("Remove non-matching elements of a collection"),
+      Signature(
+        expected = Some(Seq.empty, "A List of any sort"),
+        reqs =
+          Seq(("exp", YesNoType, "An expression to apply to the received value, which should produce True or False")),
+        opts = Seq.empty,
+        returns = (AnyType, "The elements of the List for which *exp* produced True")
+      ),
+      Details("""This function is how you take a List of things, and whittle them down to just the ones you want.
+                |
+                |*exp* should take one element from the received List, and produce a YesNo that says whether to include this Thing.
+                |That gets applied to each element of the List; if *exp* returns Yes, then it is included, otherwise not.
+                |
+                |IMPORTANT: if *exp*'s result is empty for one of the elements, it is considered to be No -- the element
+                |will be left out of the results.
+                |
+                |This is one of the most commonly-useful functions in Querki. It is how you usually say, "I only want *some*
+                |of the elements in this List or Set".""".stripMargin)
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       for {
         dummy <- inv.preferCollection(QList)
         elemContext <- inv.contextElements
         passes <- inv.processAs("exp", YesNoType, elemContext)
         if (passes)
-      }
-        yield elemContext.value
+      } yield elemContext.value
     }
   }
-  
-  lazy val SortMethod = new InternalMethod(SortMethodOID,
-      toProps(
-        setName("_sort"),
-        Categories(CollTag),
-        Summary("Sort the received list"),
-        Signature(
-          expected = Some(Seq.empty, "A List of any sort"),
-          reqs = Seq.empty,
-          opts = Seq(("exp", AnyType, Core.QNone, "One or more expressions to apply to the received values, saying how to sort them")),
-          returns = (AnyType, "The same List, sorted as requested")
-        ),        
-        Details("""With no parameters, _sort sorts the elements of the received List "naturally" -- alphabetically by their Names
-            |if they are Things, in numeric order if they are Numbers, and so on.
-            |This is what you want most of the time. However, note that many methods that return Lists are sorted to begin with,
-            |so you often don't even need to bother.
-            |
-            |If parameters are given, they are applied to each element in LIST, and the results are used to sort the
-            |elements. The sort order is whatever is natural for the returned elements -- usually alphabetical, but might be, for example,
-            |numeric if the results are numeric. It is essential that EXP return the same type for all elements, and it should return
-            |ExactlyOne value. (If it returns a List, only the first will be used. The behaviour is undefined if it returns a Set, or None.)
-            |
-            |If you need to sort on multiple fields, list them as additional parameters. For example, if you have
-            |```
-            |LIST -> _sort(A, B, C) -> SORTED
-            |```
-            |This will try to sort the list on A. When it finds multiple Things with the same value for A, it will sort them on B instead, then
-            |C, and so on.
-            |
-            |_sort is focused on Things, and as mentioned above, will default to sorting those by Name. You can also sort lists of Numbers,
-            |and many Types just work correctly, but not all. If you need to sort something, and can't make it work, please speak up.
-            |
-            |Most of the time, you will want *exp* to simply be the name of a Property. For example, this:
-            |```
-            |My Stuff._instance -> _sort(Title)
-            |```
-            |Produces all of the Instances of the "My Stuff" Model, sorted based on the "Title" Property. But it's possible to get much fancier if you need to:
-            |*exp* can be any QL Expression that receives a Link and produces a consistent Type.
-            |
-            |If you need to reverse the order of the sort, use the [[_desc._self]] method inside of it.
-            |
-            |If two or more elements being sorted have the same sort value, they will be sorted by Name.""".stripMargin)))
-  {
+
+  lazy val SortMethod = new InternalMethod(
+    SortMethodOID,
+    toProps(
+      setName("_sort"),
+      Categories(CollTag),
+      Summary("Sort the received list"),
+      Signature(
+        expected = Some(Seq.empty, "A List of any sort"),
+        reqs = Seq.empty,
+        opts = Seq((
+          "exp",
+          AnyType,
+          Core.QNone,
+          "One or more expressions to apply to the received values, saying how to sort them"
+        )),
+        returns = (AnyType, "The same List, sorted as requested")
+      ),
+      Details(
+        """With no parameters, _sort sorts the elements of the received List "naturally" -- alphabetically by their Names
+          |if they are Things, in numeric order if they are Numbers, and so on.
+          |This is what you want most of the time. However, note that many methods that return Lists are sorted to begin with,
+          |so you often don't even need to bother.
+          |
+          |If parameters are given, they are applied to each element in LIST, and the results are used to sort the
+          |elements. The sort order is whatever is natural for the returned elements -- usually alphabetical, but might be, for example,
+          |numeric if the results are numeric. It is essential that EXP return the same type for all elements, and it should return
+          |ExactlyOne value. (If it returns a List, only the first will be used. The behaviour is undefined if it returns a Set, or None.)
+          |
+          |If you need to sort on multiple fields, list them as additional parameters. For example, if you have
+          |```
+          |LIST -> _sort(A, B, C) -> SORTED
+          |```
+          |This will try to sort the list on A. When it finds multiple Things with the same value for A, it will sort them on B instead, then
+          |C, and so on.
+          |
+          |_sort is focused on Things, and as mentioned above, will default to sorting those by Name. You can also sort lists of Numbers,
+          |and many Types just work correctly, but not all. If you need to sort something, and can't make it work, please speak up.
+          |
+          |Most of the time, you will want *exp* to simply be the name of a Property. For example, this:
+          |```
+          |My Stuff._instance -> _sort(Title)
+          |```
+          |Produces all of the Instances of the "My Stuff" Model, sorted based on the "Title" Property. But it's possible to get much fancier if you need to:
+          |*exp* can be any QL Expression that receives a Link and produces a consistent Type.
+          |
+          |If you need to reverse the order of the sort, use the [[_desc._self]] method inside of it.
+          |
+          |If two or more elements being sorted have the same sort value, they will be sorted by Name.""".stripMargin
+      )
+    )
+  ) {
     // Note that we intentionally need to keep the type to compare on separate from the actual ElemValue.
     // That is because the compType might be, eg, a _desc() wrapper around the actual PType.
     sealed trait SortTerm
     case object EmptySortTerm extends SortTerm
-    case class RealSortTerm(elem:ElemValue, compType:PType[_]) extends SortTerm
-    case class SortTerms(terms:Seq[SortTerm], on:ElemValue)
-    
-    override def qlApply(inv:Invocation):QFut = {
+
+    case class RealSortTerm(
+      elem: ElemValue,
+      compType: PType[_]
+    ) extends SortTerm
+
+    case class SortTerms(
+      terms: Seq[SortTerm],
+      on: ElemValue
+    )
+
+    override def qlApply(inv: Invocation): QFut = {
       val context = inv.context
       val paramsOpt = inv.paramsOpt
-      
+
       implicit val s = context.state
       implicit val rc = context.request
-  
+
       /**
        * Compare two SortTerms.
-       * 
+       *
        * Note that this is no longer Bundle-specific -- we use it any time you provide _sort parameters.
        */
-      def bundleSortFunc(left:SortTerms, right:SortTerms):Boolean = {
-        val matchedTerms = left.terms zip right.terms
+      def bundleSortFunc(
+        left: SortTerms,
+        right: SortTerms
+      ): Boolean = {
+        val matchedTerms = left.terms.zip(right.terms)
         // Iterate over the paired elements, which correspond to the parameters to _sort. Use the first
         // result where they don't match:
         val resultOpt = (Option.empty[Boolean] /: matchedTerms) { (current, terms) =>
           current match {
             // We've already found a valid pair to sort on, so skip the rest:
             case Some(b) => current
-            
+
             // Still trying, so let's see how this pair does:
             case None => {
               val (left, right) = terms
@@ -419,22 +468,22 @@ class CollectionsModule(e:Ecology) extends QuerkiEcot(e) with querki.core.Method
             }
           }
         }
-        
+
         // No successful comparison, so we consider them to be "equal"
         resultOpt.getOrElse(false)
       }
-      
+
       /**
        * For a given Bundle, compute its sort terms based on the parameters.
        */
-      def computeSortTerms(ev:ElemValue):Future[SortTerms] = {
+      def computeSortTerms(ev: ElemValue): Future[SortTerms] = {
         paramsOpt match {
           case Some(params) => {
-            val termFuts:Seq[Future[SortTerm]] = for {
-              // For each param...
-              param <- params
-            }
-              yield for {
+            val termFuts: Seq[Future[SortTerm]] =
+              for {
+                // For each param...
+                param <- params
+              } yield for {
                 // Do some calculations and get a Future...
                 // This may return a wrapped Delegating Type. (Eg, DescendingType.)
                 tCalc <- context.parser.get.processExp(param.exp, context.next(ExactlyOne(ev))).map(_.value)
@@ -448,55 +497,56 @@ class CollectionsModule(e:Ecology) extends QuerkiEcot(e) with querki.core.Method
                       result.getOpt(LinkType) match {
                         // This is the heart of this big clause: translate UnknownOID to EmptySortTerm
                         case Some(oid) => if (oid == UnknownOID) None else Some(result)
-                        case None => Some(result)
+                        case None      => Some(result)
                       }
                     }
                   }
-                }                
+                }
               }
-                // IMPORTANT: tResult is the ElemValue, and its pType may *not* be the same as tCalc! The ElemValue
-                // is the real element, which is likely to be of the underlying PType, without any _desc wrapper
-                yield tResultOpt.map(tResult => RealSortTerm(tResult, tCalc.pType)).getOrElse(EmptySortTerm)
-            
+              // IMPORTANT: tResult is the ElemValue, and its pType may *not* be the same as tCalc! The ElemValue
+              // is the real element, which is likely to be of the underlying PType, without any _desc wrapper
+              yield tResultOpt.map(tResult => RealSortTerm(tResult, tCalc.pType)).getOrElse(EmptySortTerm)
+
             // Finally, compose the Futures together:
             for {
               terms <- Future.sequence(termFuts)
-            }
-              yield SortTerms(terms, ev)
+            } yield SortTerms(terms, ev)
           }
-          
+
           // The simple case: there are no sort parameters, so we're just sorting on displayName.
           case None => Future.successful(SortTerms(Seq.empty, ev))
         }
       }
-      
+
       /**
        * If we're comparing Things, and there are no sort terms specified, add display name as a fallback to sort on.
        * Note that we specifically want to do this here, not in bundleSortFunc, because that has to be synchronous and
        * unsafeNameOrComputed isn't.
        */
-      def computeThingSortTerms(ev:ElemValue):Future[SortTerms] = {
+      def computeThingSortTerms(ev: ElemValue): Future[SortTerms] = {
         if (paramsOpt.isEmpty || paramsOpt.get.isEmpty) {
           s.anything(LinkType.get(ev)) match {
             // PlainTextType has appropriate comparison -- in particular, it automatically compares toLowerCase.
-            case Some(thing) => thing.unsafeNameOrComputed.map(name => SortTerms(Seq(RealSortTerm(PlainTextType(name), PlainTextType)), ev))
+            case Some(thing) => thing.unsafeNameOrComputed.map(name =>
+                SortTerms(Seq(RealSortTerm(PlainTextType(name), PlainTextType)), ev)
+              )
             case _ => fut(SortTerms(Seq(EmptySortTerm), ev))
           }
         } else {
           computeSortTerms(ev)
         }
       }
-      
+
       val start = context.value.cv.toSeq
       val pType = context.value.pType
       pType match {
-        case pt:IsLinkType => {
+        case pt: IsLinkType => {
           Future.sequence(start.map(computeThingSortTerms)).map { terms =>
             val sortedOIDs = terms.sortWith(bundleSortFunc).map(terms => LinkType.get(terms.on))
-            Core.listFrom(sortedOIDs, LinkType)            
+            Core.listFrom(sortedOIDs, LinkType)
           }
         }
-        case mt:ModelTypeBase => {
+        case mt: ModelTypeBase => {
           Future.sequence(start.map(computeSortTerms)).map { terms =>
             val sortedBundles = terms.sortWith(bundleSortFunc).map(_.on)
             QList.makePropValue(sortedBundles, pType)
@@ -518,119 +568,141 @@ class CollectionsModule(e:Ecology) extends QuerkiEcot(e) with querki.core.Method
       }
     }
   }
-  
+
   /**
    * A pseudo-Type, which exists solely for the _desc method. This is a DelegatingType that is exactly like the one
    * it wraps around, except that it has a reversed sort order.
    */
   class DescendingType[VT](baseType: PType[VT]) extends DelegatingType[VT](baseType) {
-    override def doComp(context:QLContext)(left:VT, right:VT):Boolean = !realType.doComp(context)(left, right)
+
+    override def doComp(
+      context: QLContext
+    )(
+      left: VT,
+      right: VT
+    ): Boolean = !realType.doComp(context)(left, right)
   }
-  
-  lazy val DescMethod = new InternalMethod(DescMethodOID,
-      toProps(
-        setName("_desc"),
-        Categories(CollTag),
-        Summary("Sort this list in descending order"),
-        Signature(
-          expected = Some(Seq.empty, "A List of any sort"),
-          reqs = Seq(("exp", AnyType, "An expression, that you would use in _sort, which you want to reverse the order for")),
-          opts = Seq.empty,
-          returns = (AnyType, "The sort term, reversed")
-        ), 
-        Details("""_desc returns the given EXP, tweaked so that the values in it have the reversed sort order from
-            |what they would normally have. It is usually used inside of _sort, to reverse the sort order, which
-            |is normally in ascending order.
-            |
-            |For example, say that your Space was for Groceries, and you wanted to sort them by Price, with the most
-            |expensive on top. That would look something like:
-            |```
-            |\[[Grocery Item._instances -> _sort(_desc(Price))\]]
-            |```
-            |That is, "Sort the instances of Grocery Item, in descending order of Price". """.stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+
+  lazy val DescMethod = new InternalMethod(
+    DescMethodOID,
+    toProps(
+      setName("_desc"),
+      Categories(CollTag),
+      Summary("Sort this list in descending order"),
+      Signature(
+        expected = Some(Seq.empty, "A List of any sort"),
+        reqs =
+          Seq(("exp", AnyType, "An expression, that you would use in _sort, which you want to reverse the order for")),
+        opts = Seq.empty,
+        returns = (AnyType, "The sort term, reversed")
+      ),
+      Details("""_desc returns the given EXP, tweaked so that the values in it have the reversed sort order from
+                |what they would normally have. It is usually used inside of _sort, to reverse the sort order, which
+                |is normally in ascending order.
+                |
+                |For example, say that your Space was for Groceries, and you wanted to sort them by Price, with the most
+                |expensive on top. That would look something like:
+                |```
+                |\[[Grocery Item._instances -> _sort(_desc(Price))\]]
+                |```
+                |That is, "Sort the instances of Grocery Item, in descending order of Price". """.stripMargin)
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       for {
         v <- inv.process("exp")
-      }
-        yield v.cType.makePropValue(v.cv, new DescendingType(v.pType))
+      } yield v.cType.makePropValue(v.cv, new DescendingType(v.pType))
     }
   }
 
-  lazy val CountMethod = new InternalMethod(CountMethodOID,
-      toProps(
-        setName("_count"),
-        Categories(CollTag),
-        Summary("Produces the number of elements in the received Collection"),
-        Signature(
-          expected = Some(Seq.empty, "A List of any sort"),
-          reqs = Seq.empty,
-          opts = Seq.empty,
-          returns = (IntType, "How many elements are in that List")
-        ),        
-        Details("""This is pretty much as simple as it sounds. It is most often used in the header of a _section, like this:
-            |```
-            |\[[My List -> _section(\""Items: (\[[_count\]])\"", _commas)\]]
-            |```""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+  lazy val CountMethod = new InternalMethod(
+    CountMethodOID,
+    toProps(
+      setName("_count"),
+      Categories(CollTag),
+      Summary("Produces the number of elements in the received Collection"),
+      Signature(
+        expected = Some(Seq.empty, "A List of any sort"),
+        reqs = Seq.empty,
+        opts = Seq.empty,
+        returns = (IntType, "How many elements are in that List")
+      ),
+      Details(
+        """This is pretty much as simple as it sounds. It is most often used in the header of a _section, like this:
+          |```
+          |\[[My List -> _section(\""Items: (\[[_count\]])\"", _commas)\]]
+          |```""".stripMargin
+      )
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       Future.successful(ExactlyOne(IntType(inv.context.value.cv.size)))
     }
   }
-  
-  lazy val ReverseMethod = new InternalMethod(ReverseMethodOID,
-      toProps(
-        setName("_reverse"),
-        Categories(CollTag),
-        Summary("Produces the same Collection it receives, as a List, in reverse order"),
-        Signature(
-          expected = Some(Seq.empty, "A List of any sort"),
-          reqs = Seq.empty,
-          opts = Seq.empty,
-          returns = (AnyType, "The same List, in reverse order")
-        ),        
-        Details("""This does exactly what it sounds like: it produces the same list, in reversed order.
-            |
-            |_reverse can technically be used on any Collection, but is only useful for Lists. However,
-            |it can be useful after sorting a Set:
-            |```
-            |SET -> _sort -> _reverse
-            |```
-            |You can't _reverse a Set itself (Sets have their own intrinsic order), but _sort always
-            |produces a List.""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+
+  lazy val ReverseMethod = new InternalMethod(
+    ReverseMethodOID,
+    toProps(
+      setName("_reverse"),
+      Categories(CollTag),
+      Summary("Produces the same Collection it receives, as a List, in reverse order"),
+      Signature(
+        expected = Some(Seq.empty, "A List of any sort"),
+        reqs = Seq.empty,
+        opts = Seq.empty,
+        returns = (AnyType, "The same List, in reverse order")
+      ),
+      Details("""This does exactly what it sounds like: it produces the same list, in reversed order.
+                |
+                |_reverse can technically be used on any Collection, but is only useful for Lists. However,
+                |it can be useful after sorting a Set:
+                |```
+                |SET -> _sort -> _reverse
+                |```
+                |You can't _reverse a Set itself (Sets have their own intrinsic order), but _sort always
+                |produces a List.""".stripMargin)
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       Future.successful(QList.makePropValue(inv.context.value.cv.toSeq.reverse.toList, inv.context.value.pType))
     }
   }
-  
-  lazy val prevInListMethod = new InternalMethod(PrevInListOID,
-      toProps(
-        setName("_prevInList"),
-        Categories(CollTag),
-        SkillLevel(SkillLevelAdvanced),
-        Summary("Fetch the previous value to this one from the given List"),
-        Signature(
-          expected = Some(Seq.empty, "Something that you expect to find in the List"),
-          reqs = Seq(("list", AnyType, "An expression that produces a List")),
-          opts = Seq.empty,
-          returns = (AnyType, "The previous element in *list*. None if the received value was at the beginning, or isn't contained in the *list*")
-        ),        
-        Details("""Given a received value, and a *list* that contains that value, this returns the *previous* element to that
-            |in the *list*.
-            |
-            |For example, say that your Space has a collection of Fruit, including Apple, Banana, Blackberry, Kiwi and Pear, and you
-            |want to be able to navigate between them. In the Default View for Fruit, you could create a button that goes to the
-            |previous one like this:
-            |```
-            |\[[_prevInList(Fruit._instances) -> _linkButton(\""Previous Fruit\"")\]]
-            |```""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+
+  lazy val prevInListMethod = new InternalMethod(
+    PrevInListOID,
+    toProps(
+      setName("_prevInList"),
+      Categories(CollTag),
+      SkillLevel(SkillLevelAdvanced),
+      Summary("Fetch the previous value to this one from the given List"),
+      Signature(
+        expected = Some(Seq.empty, "Something that you expect to find in the List"),
+        reqs = Seq(("list", AnyType, "An expression that produces a List")),
+        opts = Seq.empty,
+        returns = (
+          AnyType,
+          "The previous element in *list*. None if the received value was at the beginning, or isn't contained in the *list*"
+        )
+      ),
+      Details("""Given a received value, and a *list* that contains that value, this returns the *previous* element to that
+                |in the *list*.
+                |
+                |For example, say that your Space has a collection of Fruit, including Apple, Banana, Blackberry, Kiwi and Pear, and you
+                |want to be able to navigate between them. In the Default View for Fruit, you could create a button that goes to the
+                |previous one like this:
+                |```
+                |\[[_prevInList(Fruit._instances) -> _linkButton(\""Previous Fruit\"")\]]
+                |```""".stripMargin)
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       for {
         v <- inv.process("list")
-      }
-      yield {
+      } yield {
         val elem = inv.context.value.first
         val index = v.indexOf(elem)
         index match {
@@ -645,34 +717,39 @@ class CollectionsModule(e:Ecology) extends QuerkiEcot(e) with querki.core.Method
       }
     }
   }
-  
-  lazy val nextInListMethod = new InternalMethod(NextInListOID,
-      toProps(
-        setName("_nextInList"),
-        Categories(CollTag),
-        SkillLevel(SkillLevelAdvanced),
-        Summary("Fetch the next value to this one from the given List"),
-        Signature(
-          expected = Some(Seq.empty, "Something that you expect to find in the List"),
-          reqs = Seq(("list", AnyType, "An expression that produces a List")),
-          opts = Seq.empty,
-          returns = (AnyType, "The next element in *list*. None if the received value was at the end, or isn't contained in the *list*")
-        ),        
-        Details("""Given a received value, and a *list* that contains that value, this returns the *next* element to that
-            |in the *list*.
-            |
-            |For example, say that your Space has a collection of Fruit, including Apple, Banana, Blackberry, Kiwi and Pear, and you
-            |want to be able to navigate between them. In the Default View for Fruit, you could create a button that goes to the
-            |next one like this:
-            |```
-            |\[[_nextInList(Fruit._instances) -> _linkButton(\""Next Fruit\"")\]]
-            |```""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+
+  lazy val nextInListMethod = new InternalMethod(
+    NextInListOID,
+    toProps(
+      setName("_nextInList"),
+      Categories(CollTag),
+      SkillLevel(SkillLevelAdvanced),
+      Summary("Fetch the next value to this one from the given List"),
+      Signature(
+        expected = Some(Seq.empty, "Something that you expect to find in the List"),
+        reqs = Seq(("list", AnyType, "An expression that produces a List")),
+        opts = Seq.empty,
+        returns = (
+          AnyType,
+          "The next element in *list*. None if the received value was at the end, or isn't contained in the *list*"
+        )
+      ),
+      Details("""Given a received value, and a *list* that contains that value, this returns the *next* element to that
+                |in the *list*.
+                |
+                |For example, say that your Space has a collection of Fruit, including Apple, Banana, Blackberry, Kiwi and Pear, and you
+                |want to be able to navigate between them. In the Default View for Fruit, you could create a button that goes to the
+                |next one like this:
+                |```
+                |\[[_nextInList(Fruit._instances) -> _linkButton(\""Next Fruit\"")\]]
+                |```""".stripMargin)
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       for {
         v <- inv.process("list")
-      }
-      yield {
+      } yield {
         val elem = inv.context.value.first
         val index = v.indexOf(elem)
         index match {
@@ -687,38 +764,48 @@ class CollectionsModule(e:Ecology) extends QuerkiEcot(e) with querki.core.Method
       }
     }
   }
-  
-  lazy val foreachMethod = new InternalMethod(ForeachMethodOID,
-      toProps(
-        setName("_foreach"),
-        Categories(CollTag),
-        Summary("Applies the parameter to each element in the received collection, and produces a collection of the results"),
-        Signature(
-          expected = Some(Seq.empty, "A List or Set of any sort"),
-          reqs = Seq(("exp", AnyType, "An expression to run on each element of the collection")),
-          opts = Seq.empty,
-          returns = (AnyType, "The results of running *exp* on each element")
-        ), 
-        Details("""Otherwise known as "map" in many programming languages, this lets you take an expression or function
-                |that operates on a single element, and apply it to each element in the received collection.""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+
+  lazy val foreachMethod = new InternalMethod(
+    ForeachMethodOID,
+    toProps(
+      setName("_foreach"),
+      Categories(CollTag),
+      Summary(
+        "Applies the parameter to each element in the received collection, and produces a collection of the results"
+      ),
+      Signature(
+        expected = Some(Seq.empty, "A List or Set of any sort"),
+        reqs = Seq(("exp", AnyType, "An expression to run on each element of the collection")),
+        opts = Seq.empty,
+        returns = (AnyType, "The results of running *exp* on each element")
+      ),
+      Details(
+        """Otherwise known as "map" in many programming languages, this lets you take an expression or function
+          |that operates on a single element, and apply it to each element in the received collection.""".stripMargin
+      )
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       for {
         elemContext <- inv.contextElements
         elemResult <- inv.process("exp", elemContext)
-      }
-        yield elemResult
+      } yield elemResult
     }
   }
-  
+
   /**
    * Common core of _contains and _isContainedIn.
    */
-  def checkContains(container: QValue, contained: QValue, requireAll: Boolean): Boolean = {
+  def checkContains(
+    container: QValue,
+    contained: QValue,
+    requireAll: Boolean
+  ): Boolean = {
     if (contained.size == 1) {
       contained.firstOpt.map { elem =>
         container.contains(elem)
-      }.getOrElse(false)      
+      }.getOrElse(false)
     } else if (requireAll) {
       contained.elems.forall { elem =>
         container.contains(elem)
@@ -729,58 +816,80 @@ class CollectionsModule(e:Ecology) extends QuerkiEcot(e) with querki.core.Method
       }
     }
   }
-  
-  lazy val containsMethod = new InternalMethod(ContainsMethodOID,
+
+  lazy val containsMethod = new InternalMethod(
+    ContainsMethodOID,
     toProps(
       setName("_contains"),
       Categories(CollTag),
       Summary("Produces true if the received List contains the specified value"),
       Signature(
         expected = Some(Seq.empty, "A List (or Set) of any sort"),
-        reqs = Seq(("v", AnyType, "A single value that might be in the List. This should be Required; if not, the first element will be used.")),
+        reqs = Seq((
+          "v",
+          AnyType,
+          "A single value that might be in the List. This should be Required; if not, the first element will be used."
+        )),
         opts = Seq(
-          ("all", YesNoType, false, "If you set this to true, *all* of the values must be present; otherwise, it will return true if *any* are present.")
+          (
+            "all",
+            YesNoType,
+            false,
+            "If you set this to true, *all* of the values must be present; otherwise, it will return true if *any* are present."
+          )
         ),
         returns = (YesNoType, "True if *v* is found in the List; False otherwise")
       ),
-      Details("See [[_isContainedIn._self]] for the inverse of this function.")))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+      Details("See [[_isContainedIn._self]] for the inverse of this function.")
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       for {
         compareTo <- inv.process("v")
         all <- inv.processAs("all", YesNoType)
         result = checkContains(inv.context.value, compareTo, all)
-      }
-        yield boolean2YesNoQValue(result)
+      } yield boolean2YesNoQValue(result)
     }
   }
-  
-  lazy val isContainedInMethod = new InternalMethod(IsContainedInMethodOID,
+
+  lazy val isContainedInMethod = new InternalMethod(
+    IsContainedInMethodOID,
     toProps(
       setName("_isContainedIn"),
       Categories(CollTag),
       Summary("Produces true if the received value is found in the specified List"),
       Signature(
-        expected = Some(Seq.empty, "A Value; if this a List or Set, the first element will be used. If Empty, this will always return False."),
+        expected = Some(
+          Seq.empty,
+          "A Value; if this a List or Set, the first element will be used. If Empty, this will always return False."
+        ),
         reqs = Seq(("l", AnyType, "A List that might contain that Value.")),
         opts = Seq(
-          ("all", YesNoType, false, "If you set this to true, *all* of the values must be present; otherwise, it will return true if *any* are present.")
+          (
+            "all",
+            YesNoType,
+            false,
+            "If you set this to true, *all* of the values must be present; otherwise, it will return true if *any* are present."
+          )
         ),
         returns = (YesNoType, "True if that Value is found in the List; False otherwise")
       ),
-      Details("See [[_contains._self]] for the inverse of this function.")))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+      Details("See [[_contains._self]] for the inverse of this function.")
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       for {
         listv <- inv.process("l")
         all <- inv.processAs("all", YesNoType)
         result = checkContains(listv, inv.context.value, all)
-      }
-        yield boolean2YesNoQValue(result)
+      } yield boolean2YesNoQValue(result)
     }
   }
 
-  lazy val ConcatMethod = new InternalMethod(ConcatOID,
+  lazy val ConcatMethod = new InternalMethod(
+    ConcatOID,
     toProps(
       setName("_concat"),
       Categories(CollTag),
@@ -790,19 +899,21 @@ class CollectionsModule(e:Ecology) extends QuerkiEcot(e) with querki.core.Method
         reqs = Seq(("lists", AnyType, "One or more lists")),
         opts = Seq.empty,
         returns = (AnyType, "All of the given *lists*, concatenated together")
-      ), 
+      ),
       Details("""Occasionally, you want to take several separate lists, and treat them as a single list. This allows
-          |you to do something like
-          |```
-          |\[[My Thing -> _concat(Primary Sources, Secondary Sources) -> _bulleted\]]
-          |```
-          |Note that the received context will be passed to each of the expressions in *lists*, as usual, but
-          |otherwise isn't relevant. You can write expressions that completely ignore the received context.
-          |
-          |You can `_concat` lists that are of different but compatible Types. If you do this, the resulting
-          |list will all be coerced to the *first* Type found.""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+                |you to do something like
+                |```
+                |\[[My Thing -> _concat(Primary Sources, Secondary Sources) -> _bulleted\]]
+                |```
+                |Note that the received context will be passed to each of the expressions in *lists*, as usual, but
+                |otherwise isn't relevant. You can write expressions that completely ignore the received context.
+                |
+                |You can `_concat` lists that are of different but compatible Types. If you do this, the resulting
+                |list will all be coerced to the *first* Type found.""".stripMargin)
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       // TODO: this is using local mutable state, which is fugly. What's a better pattern for us to
       // find the first "real" PType in the list? Something involving the State monad?
       // TODO: no, it's worse than that: this is actually broken. InvocationValueImpl.flatMap() does
@@ -811,7 +922,7 @@ class CollectionsModule(e:Ecology) extends QuerkiEcot(e) with querki.core.Method
       // is proving flaky!
       var targetType: Option[PType[_]] = None
       for {
-        n <- inv.iter(0 to (inv.numParams-1))
+        n <- inv.iter(0 to (inv.numParams - 1))
         paramVals <- inv.processParam(n)
         typeCheck <-
           if (targetType.isEmpty) {
@@ -823,16 +934,17 @@ class CollectionsModule(e:Ecology) extends QuerkiEcot(e) with querki.core.Method
           } else {
             // We've found a real PType, so this one has to match or be empty:
             inv.test(
-              paramVals.isEmpty || ElemValue.matchesType(paramVals.pType, targetType.get), 
-              "Collections.concat.mismatchedTypes", 
-              { Seq(targetType.get.displayName, paramVals.pType.displayName) })
+              paramVals.isEmpty || ElemValue.matchesType(paramVals.pType, targetType.get),
+              "Collections.concat.mismatchedTypes",
+              { Seq(targetType.get.displayName, paramVals.pType.displayName) }
+            )
           }
-      }
-        yield paramVals
+      } yield paramVals
     }
   }
-  
-  lazy val RandomMethod = new InternalMethod(RandomOID,
+
+  lazy val RandomMethod = new InternalMethod(
+    RandomOID,
     toProps(
       setName("_random"),
       Categories(CollTag),
@@ -842,101 +954,109 @@ class CollectionsModule(e:Ecology) extends QuerkiEcot(e) with querki.core.Method
         reqs = Seq.empty,
         opts = Seq.empty,
         returns = (AnyType, "A random element from the List")
-      ), 
+      ),
       Details("""Most of the time, you want your Querki pages to be nice and predictable. But occasionally,
-          |you might want some randomness. For example, if you have a Cookbook Space, you might want a
-          |page that gives you a recipe at random, to give you ideas for dinner. The _random function
-          |does that, allowing you to do something like:
-          |```
-          |\[[Recipes._instances -> _random\]]
-          |```""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+                |you might want some randomness. For example, if you have a Cookbook Space, you might want a
+                |page that gives you a recipe at random, to give you ideas for dinner. The _random function
+                |does that, allowing you to do something like:
+                |```
+                |\[[Recipes._instances -> _random\]]
+                |```""".stripMargin)
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       import scala.math._
       for {
         v <- inv.contextValue
         len = v.cv.size
         rnd = floor(random * len).toInt
         item = v.cv.drop(rnd).head
-      }
-        yield ExactlyOne(item)
+      } yield ExactlyOne(item)
     }
   }
-  
-  lazy val FoldFunction = new InternalMethod(FoldFunctionOID,
-      toProps(
-        setName("_fold"),
-        Categories(CollTag),
-        Summary("Applies a QL expression iteratively to the elements of a List"),
-        SkillLevel(SkillLevelAdvanced),
-        Signature(
-          expected = Some(Seq.empty, "A List of any sort"),
-          reqs = Seq(
-            ("init", AnyType, "The start value"),
-            ("exp", AnyType, "An expression to run on each element of the collection")
-          ),
-          opts = Seq.empty,
-          returns = (AnyType, "The result of running `exp` over each element of the List")
-        ),        
-        Details("""This function is advanced, but sometimes enormously useful. It is Querki's version
-                  |of the common functional-programming function fold().
-                  |
-                  |Basically, this receives a List, and takes two parameters: an initial value and
-                  |an expression. It runs through the List, one element at a time, building up an
-                  |"accumulator". Each time through, you get the current accumulator and the next
-                  |element; the expression should result in a new value, which will become the
-                  |new accumulator.
-                  |
-                  |The accumulator is passed into the expression as the bound name `$acc`; the next
-                  |element as `$next`.
-                  |
-                  |It is best understood through an example. This is how you would implement "sum"
-                  |using `_fold`:
-                  |
-                  |```
-                  |<1, 2, 3, 4> -> _fold(0, $acc -> _plus($next))
-                  |```
-                  |
-                  |That is, you can think of a sum as simply adding all of the elements together
-                  |one at a time. So you start with 0 (the first parameter). The first time it
-                  |calls the expression, `$acc` is 0 and `$next` is 1 (the first element of the List),
-                  |so it results in 1. Next time around, `$acc` is 1 and `$next` is 2 (the next element),
-                  |so it results in 3. Then it adds 3 and 3 to get 6; then it adds 6 and 4, to get 10.
-                  |
-                  |For convenience, the value of `$acc` is also given at the context of the expression.
-                  |So you could actually express the above even more concisely as:
-                  |
-                  |```
-                  |<1, 2, 3, 4> -> _fold(0, _plus($next))
-                  |```
-                  |""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+
+  lazy val FoldFunction = new InternalMethod(
+    FoldFunctionOID,
+    toProps(
+      setName("_fold"),
+      Categories(CollTag),
+      Summary("Applies a QL expression iteratively to the elements of a List"),
+      SkillLevel(SkillLevelAdvanced),
+      Signature(
+        expected = Some(Seq.empty, "A List of any sort"),
+        reqs = Seq(
+          ("init", AnyType, "The start value"),
+          ("exp", AnyType, "An expression to run on each element of the collection")
+        ),
+        opts = Seq.empty,
+        returns = (AnyType, "The result of running `exp` over each element of the List")
+      ),
+      Details("""This function is advanced, but sometimes enormously useful. It is Querki's version
+                |of the common functional-programming function fold().
+                |
+                |Basically, this receives a List, and takes two parameters: an initial value and
+                |an expression. It runs through the List, one element at a time, building up an
+                |"accumulator". Each time through, you get the current accumulator and the next
+                |element; the expression should result in a new value, which will become the
+                |new accumulator.
+                |
+                |The accumulator is passed into the expression as the bound name `$acc`; the next
+                |element as `$next`.
+                |
+                |It is best understood through an example. This is how you would implement "sum"
+                |using `_fold`:
+                |
+                |```
+                |<1, 2, 3, 4> -> _fold(0, $acc -> _plus($next))
+                |```
+                |
+                |That is, you can think of a sum as simply adding all of the elements together
+                |one at a time. So you start with 0 (the first parameter). The first time it
+                |calls the expression, `$acc` is 0 and `$next` is 1 (the first element of the List),
+                |so it results in 1. Next time around, `$acc` is 1 and `$next` is 2 (the next element),
+                |so it results in 3. Then it adds 3 and 3 to get 6; then it adds 6 and 4, to get 10.
+                |
+                |For convenience, the value of `$acc` is also given at the context of the expression.
+                |So you could actually express the above even more concisely as:
+                |
+                |```
+                |<1, 2, 3, 4> -> _fold(0, _plus($next))
+                |```
+                |""".stripMargin)
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       for {
         init <- inv.process("init")
         exp <- inv.rawRequiredParam("exp")
         result <- inv.fut(doFold(init, inv.context, exp))
-      }
-        yield result
+      } yield result
     }
-    
-    def doFold(init: QValue, context: QLContext, exp: querki.ql.QLExp): Future[QValue] = {
+
+    def doFold(
+      init: QValue,
+      context: QLContext,
+      exp: querki.ql.QLExp
+    ): Future[QValue] = {
       (Future.successful(init) /: context.value.elems) { (accFut, elem) =>
         accFut.flatMap { acc =>
-          val parser = context.parser.get.
-            withBindings(Map(
-              ("acc" -> acc),
-              ("next" -> ExactlyOne(elem))
-            ))
-          val elemContext = parser.initialContext.next(acc)
-          
+          val parser = context.parser.get.withBindings(Map(
+            ("acc" -> acc),
+            ("next" -> ExactlyOne(elem))
+          ))
+          val elemContext = parser.processor.initialContext.next(acc)
+
           parser.processExp(exp, elemContext).map(_.value)
         }
       }
     }
   }
 
-  lazy val PositionsMethod = new AbstractFunction(PositionsMethodOID, Received,
+  lazy val PositionsMethod = new AbstractFunction(
+    PositionsMethodOID,
+    Received,
     toProps(
       setName("_positions"),
       Categories(CollTag),
@@ -946,9 +1066,11 @@ class CollectionsModule(e:Ecology) extends QuerkiEcot(e) with querki.core.Method
           |This looks for `SUBVALUE` inside of `VALUE`, and returns a list of all locations where it is found.
           |The exact meaning of "locations" depends on the type of `VALUE`. If `SUBVALUE` is not found, the resulting
           |list will be empty.
-        """.stripMargin)
-    ))
-  
+        """.stripMargin
+      )
+    )
+  )
+
   override lazy val props = Seq(
     FirstMethod,
     RestMethod,
@@ -964,7 +1086,6 @@ class CollectionsModule(e:Ecology) extends QuerkiEcot(e) with querki.core.Method
     ConcatMethod,
     RandomMethod,
     FoldFunction,
-      
     prevInListMethod,
     nextInListMethod,
     foreachMethod,
@@ -972,5 +1093,5 @@ class CollectionsModule(e:Ecology) extends QuerkiEcot(e) with querki.core.Method
     isContainedInMethod,
     PositionsMethod
   )
-  
+
 }

--- a/querki/scalajvm/app/querki/editing/EditorModule.scala
+++ b/querki/scalajvm/app/querki/editing/EditorModule.scala
@@ -18,14 +18,14 @@ import querki.types._
 import querki.util._
 import querki.values._
 
-class EditorModule(e:Ecology) extends QuerkiEcot(e) with Editor with querki.core.MethodDefs with ThingEditor {
+class EditorModule(e: Ecology) extends QuerkiEcot(e) with Editor with querki.core.MethodDefs with ThingEditor {
   import MOIDs._
-  
+
   val Types = initRequires[querki.types.Types]
   val Basic = initRequires[querki.basic.Basic]
   val Logic = initRequires[querki.logic.Logic]
   val Links = initRequires[querki.links.Links]
-  
+
   lazy val AccessControl = interface[querki.security.AccessControl]
   lazy val ApiRegistry = interface[querki.api.ApiRegistry]
   lazy val Apps = interface[querki.apps.Apps]
@@ -37,48 +37,71 @@ class EditorModule(e:Ecology) extends QuerkiEcot(e) with Editor with querki.core
   lazy val SkillLevel = interface[querki.identity.skilllevel.SkillLevel]
   lazy val SpaceOps = interface[querki.spaces.SpaceOps]
   lazy val UserValues = interface[querki.uservalues.UserValues]
-  
+
   lazy val PlainTextType = Basic.PlainTextType
-  
+
   lazy val DisplayTextProp = Basic.DisplayTextProp
   lazy val NameProp = Core.NameProp
-  
+
   override def postInit() = {
     ApiRegistry.registerApiImplFor[EditFunctions, EditFunctionsImpl](SpaceOps.spaceRegion)
   }
-  
-  def getInstanceEditor(thing:PropertyBundle, context:QLContext, currentValue:Option[DisplayPropVal] = None):Future[Wikitext] = {
-    instanceEditorForThing(thing, context.next(thing.thisAsQValue).copy(currentValue = currentValue)(context.state, ecology), None)
+
+  def getInstanceEditor(
+    thing: PropertyBundle,
+    context: QLContext,
+    currentValue: Option[DisplayPropVal] = None
+  ): Future[Wikitext] = {
+    instanceEditorForThing(
+      thing,
+      context.next(thing.thisAsQValue).copy(currentValue = currentValue)(context.state, ecology),
+      None
+    )
   }
-  
-  /***********************************************
+
+  /**
+   * *********************************************
    * PROPERTIES
-   ***********************************************/
-    
-  lazy val PlaceholderTextProp = new SystemProperty(PlaceholderTextOID, PlainTextType, Optional,
+   * *********************************************
+   */
+
+  lazy val PlaceholderTextProp = new SystemProperty(
+    PlaceholderTextOID,
+    PlainTextType,
+    Optional,
     toProps(
       setName("Placeholder Text"),
       AppliesToKindProp(Kind.Property),
       Basic.DeprecatedProp(true),
       Summary("Placeholder text for input boxes"),
       Details("""In Text Properties, it is often helpful to have a prompt that displays inside the input
-          |field until the user begins to type something there. If the Property has a Placeholder Text, that
-          |will be displayed in grey when the input is first shown.""".stripMargin)
-      ))
-  
-  lazy val PromptProp = new SystemProperty(PromptOID, PlainTextType, Optional,
+                |field until the user begins to type something there. If the Property has a Placeholder Text, that
+                |will be displayed in grey when the input is first shown.""".stripMargin)
+    )
+  )
+
+  lazy val PromptProp = new SystemProperty(
+    PromptOID,
+    PlainTextType,
+    Optional,
     toProps(
       setName("Prompt"),
       AppliesToKindProp(Kind.Property),
       Categories(EditingTag),
       Summary("Prompt to use in the Editor"),
-      Details("""In the Editor, Properties are usually displayed with their Name. If you want to show something
-          |other than the Name, set the Prompt Property to say what you would like to show instead.""".stripMargin)
-      ))
-	
-	// TODO: this should really only allow the properties that are defined on this Model:
-    // TODO: this has broadened in scope, and really doesn't belong in Editor any more:
-	lazy val InstanceProps = new SystemProperty(InstanceEditPropsOID, LinkType, QList,
+      Details(
+        """In the Editor, Properties are usually displayed with their Name. If you want to show something
+          |other than the Name, set the Prompt Property to say what you would like to show instead.""".stripMargin
+      )
+    )
+  )
+
+  // TODO: this should really only allow the properties that are defined on this Model:
+  // TODO: this has broadened in scope, and really doesn't belong in Editor any more:
+  lazy val InstanceProps = new SystemProperty(
+    InstanceEditPropsOID,
+    LinkType,
+    QList,
     toProps(
       setName(commonName(_.editing.instancePropsProp)),
       Links.LinkAllowAppsProp(true),
@@ -87,56 +110,81 @@ class EditorModule(e:Ecology) extends QuerkiEcot(e) with Editor with querki.core
       Categories(EditingTag),
       Summary("Which Properties are relevant for Instances of this Model?"),
       Details("""This Property defines which of the Properties on this Model will show in
-        |the editor for its Instances, and in what order.
-        |
-        |You usually should not need to set this manually; it is changed by dragging-and-dropping
-        |Properties in the Model Editor.""".stripMargin))) with LinkCandidateProvider
-	{
-	  def getLinkCandidates(state:SpaceState, currentValue:DisplayPropVal):Seq[Thing] = {
-	    currentValue.on match {
-	      case Some(thing) => {
-	        // We're applying this to some actual thing, so list its Properties as options:
-	        thing.allProps(state).toSeq.sortBy(_.displayName)
-	      }
-	      case _ => Seq.empty
-	    }
-	  }
-	}
+                |the editor for its Instances, and in what order.
+                |
+                |You usually should not need to set this manually; it is changed by dragging-and-dropping
+                |Properties in the Model Editor.""".stripMargin)
+    )
+  ) with LinkCandidateProvider {
 
-  lazy val InstanceEditViewProp = new SystemProperty(InstanceEditViewOID, LargeTextType, ExactlyOne,
+    def getLinkCandidates(
+      state: SpaceState,
+      currentValue: DisplayPropVal
+    ): Seq[Thing] = {
+      currentValue.on match {
+        case Some(thing) => {
+          // We're applying this to some actual thing, so list its Properties as options:
+          thing.allProps(state).toSeq.sortBy(_.displayName)
+        }
+        case _ => Seq.empty
+      }
+    }
+  }
+
+  lazy val InstanceEditViewProp = new SystemProperty(
+    InstanceEditViewOID,
+    LargeTextType,
+    ExactlyOne,
     toProps(
       setName("Instance Edit View"),
       Categories(EditingTag),
       Summary("Defines the Edit View for Instances of this Model"),
       Details("""Sometimes, you want to customize your editing experience -- to make things easier or more
-          |efficient, or prettier for your users. Regardless of the reason, this Property gives you complete
-          |control.
-          |
-          |This is an arbitrary Large Text, which is shown whenever you say
-          |[[_code(""[[My Instance._edit]]"")]]
-          |The contents are up to you, but it should usually contain _edit functions for each Property you
-          |want to be editable.""".stripMargin)))
-  
-  lazy val EditWidthProp = new SystemProperty(EditWidthPropOID, IntType, ExactlyOne,
+                |efficient, or prettier for your users. Regardless of the reason, this Property gives you complete
+                |control.
+                |
+                |This is an arbitrary Large Text, which is shown whenever you say
+                |[[_code(""[[My Instance._edit]]"")]]
+                |The contents are up to you, but it should usually contain _edit functions for each Property you
+                |want to be editable.""".stripMargin)
+    )
+  )
+
+  lazy val EditWidthProp = new SystemProperty(
+    EditWidthPropOID,
+    IntType,
+    ExactlyOne,
     toProps(
       setName("Edit Width"),
       Types.MinIntValueProp(1),
       Types.MaxIntValueProp(12),
       Categories(EditingTag),
       Summary("Lets you control how wide a Property's edit control is, in the Edit View"),
-      Details("""This is width in Bootstrap span terms -- a number from 1 (narrow) to 12 (full width).
-        |
-        |You do not have to set this -- if you leave it alone, each Type has a default width. But you will
-        |sometimes find that you prefer to have your Edit controls narrower then the default, in order to
-        |get a good-looking Editor for a Model. Set this to a number between 1 and 12 to do that.""".stripMargin)))
-  
-  lazy val NotEditableProp = new SystemProperty(NotEditableOID, YesNoType, ExactlyOne,
+      Details(
+        """This is width in Bootstrap span terms -- a number from 1 (narrow) to 12 (full width).
+          |
+          |You do not have to set this -- if you leave it alone, each Type has a default width. But you will
+          |sometimes find that you prefer to have your Edit controls narrower then the default, in order to
+          |get a good-looking Editor for a Model. Set this to a number between 1 and 12 to do that.""".stripMargin
+      )
+    )
+  )
+
+  lazy val NotEditableProp = new SystemProperty(
+    NotEditableOID,
+    YesNoType,
+    ExactlyOne,
     toProps(
       setName("_Not Editable Property"),
       setInternal,
-      Summary("Set on a Property that should not show up in the Editor.")))
-  
-  lazy val PreferredCollectionProp = new SystemProperty(PreferredCollectionOID, LinkType, Optional,
+      Summary("Set on a Property that should not show up in the Editor.")
+    )
+  )
+
+  lazy val PreferredCollectionProp = new SystemProperty(
+    PreferredCollectionOID,
+    LinkType,
+    Optional,
     toProps(
       setName("_Preferred Collection for Type"),
       Categories(EditingTag),
@@ -149,19 +197,33 @@ class EditorModule(e:Ecology) extends QuerkiEcot(e) with Editor with querki.core
         |`_Preferred Collection for Type` declares which Collection is *best* for this Type. Note
         |that this is just a default used in the Create Property editor -- it is not enforced.
         |
-        |If this is not set on a given Type, it will default to Optional.""")))
+        |If this is not set on a given Type, it will default to Optional.""")
+    )
+  )
 
-  abstract class EditMethodBase(id:OID, pf:PropMap) extends InternalMethod(id, pf)
-  {
-    def specialization(mainContext:QLContext, mainThing:PropertyBundle, 
-      partialContext:QLContext, prop:Property[_,_],
-      params:Option[Seq[QLParam]]):Set[RenderSpecialization] = Set(FromEditFunction)
-  
-    def cantEditFallback(inv:Invocation):Future[QValue]
-    
-    def canEdit(context:QLContext, requester:User, thing:PropertyBundle, prop:Property[_,_]):Boolean = {
+  abstract class EditMethodBase(
+    id: OID,
+    pf: PropMap
+  ) extends InternalMethod(id, pf) {
+
+    def specialization(
+      mainContext: QLContext,
+      mainThing: PropertyBundle,
+      partialContext: QLContext,
+      prop: Property[_, _],
+      params: Option[Seq[QLParam]]
+    ): Set[RenderSpecialization] = Set(FromEditFunction)
+
+    def cantEditFallback(inv: Invocation): Future[QValue]
+
+    def canEdit(
+      context: QLContext,
+      requester: User,
+      thing: PropertyBundle,
+      prop: Property[_, _]
+    ): Boolean = {
       thing match {
-        case t:Thing => {
+        case t: Thing => {
           implicit val state = context.state
           if (UserValues.isUserValueProp(prop))
             AccessControl.hasPermission(UserValues.UserValuePermission, state, requester, t.id)
@@ -173,34 +235,46 @@ class EditorModule(e:Ecology) extends QuerkiEcot(e) with Editor with querki.core
         case _ => true
       }
     }
-  
-    def applyToPropAndThing(inv:Invocation, elemContext:QLContext, mainThing:PropertyBundle, 
-      definingContext:QLContext, prop:Property[_,_],
-      params:Option[Seq[QLParam]]):QFut =
-    {
+
+    def applyToPropAndThing(
+      inv: Invocation,
+      elemContext: QLContext,
+      mainThing: PropertyBundle,
+      definingContext: QLContext,
+      prop: Property[_, _],
+      params: Option[Seq[QLParam]]
+    ): QFut = {
       elemContext.request.requester match {
         case Some(requester) if (canEdit(elemContext, requester, mainThing, prop)) => {
           val currentValue = mainThing.getDisplayPropVal(prop)(elemContext.state).copy(cont = elemContext.currentValue)
-	        // TODO: conceptually, this is a bit off -- the rendering style shouldn't be hard-coded here. We
-  	      // probably need to have the Context contain the desire to render in HTML, and delegate to the
-  	      // HTML renderer indirectly. In other words, the Context should know the renderer to use, and pass
-  	      // that into here:
+          // TODO: conceptually, this is a bit off -- the rendering style shouldn't be hard-coded here. We
+          // probably need to have the Context contain the desire to render in HTML, and delegate to the
+          // HTML renderer indirectly. In other words, the Context should know the renderer to use, and pass
+          // that into here:
           for {
-  	        inputControl <- HtmlRenderer.renderPropertyInput(elemContext, prop, currentValue, 
-  	          specialization(elemContext, mainThing, definingContext, prop, params))
-          }
-  	        yield HtmlUI.HtmlValue(inputControl)    
+            inputControl <- HtmlRenderer.renderPropertyInput(
+              elemContext,
+              prop,
+              currentValue,
+              specialization(elemContext, mainThing, definingContext, prop, params)
+            )
+          } yield HtmlUI.HtmlValue(inputControl)
         }
         case _ => cantEditFallback(inv)
       }
     }
-  
-    override def qlApply(inv:Invocation):QFut = {
+
+    override def qlApply(inv: Invocation): QFut = {
       val mainContext = inv.context
       val partialContextOpt = inv.definingContext
       val params = inv.paramsOpt
-      
-      def editThing(thing:Thing, context:QLContext)(implicit state:SpaceState):QFut = {
+
+      def editThing(
+        thing: Thing,
+        context: QLContext
+      )(implicit
+        state: SpaceState
+      ): QFut = {
         if (thing.ifSet(Core.IsModelProp)) {
           val allInstances = state.descendants(thing.id, false, true).toSeq.sortBy(_.displayName)
           for {
@@ -209,14 +283,17 @@ class EditorModule(e:Ecology) extends QuerkiEcot(e) with Editor with querki.core
             pageSize <- inv.processParamFirstAs(1, IntType)
             startAt = pageSize * page
             instance <- inv.iter(allInstances.drop(startAt).take(pageSize))
-            wikitext <- inv.fut(instanceEditorForThing(instance, instance.thisAsContext(context.request, state, ecology), Some(inv)))
-          }
-            yield ExactlyOne(QL.ParsedTextType(wikitext))
+            wikitext <- inv.fut(instanceEditorForThing(
+              instance,
+              instance.thisAsContext(context.request, state, ecology),
+              Some(inv)
+            ))
+          } yield ExactlyOne(QL.ParsedTextType(wikitext))
         } else {
           instanceEditorForThing(thing, context, Some(inv)).map(QL.WikitextValue)
         }
       }
-      
+
       partialContextOpt match {
         case Some(definingContext) => {
           // [[THINGS -> PROP._edit]] -- there is a PROP specified
@@ -224,26 +301,29 @@ class EditorModule(e:Ecology) extends QuerkiEcot(e) with Editor with querki.core
             prop <- inv.definingContextAsProperty
             (bundle, elemContext) <- inv.contextBundlesAndContexts
             result <- inv.fut(applyToPropAndThing(inv, elemContext, bundle, definingContext, prop, params))
-          }
-            yield result 
+          } yield result
         }
-        
+
         case None => {
           // [[THINGS -> _edit]] -- there is no PROP specified
           for {
             thing <- inv.contextAllThings
             result <- inv.fut(editThing(thing, inv.context)(inv.state))
-          }
-            yield result
+          } yield result
         }
-      } 
+      }
     }
   }
-  
+
   /**
    * This is a place to stick weird, special filters.
    */
-  def specialModelFilter(model:PropertyBundle, prop:Property[_,_])(implicit state:SpaceState):Boolean = {
+  def specialModelFilter(
+    model: PropertyBundle,
+    prop: Property[_, _]
+  )(implicit
+    state: SpaceState
+  ): Boolean = {
     // We display Default View iff it is defined locally on this Thing, or it is *not*
     // defined for the Model.
     // TBD: this is kind of a weird hack. Is it peculiar to Default View, or is there
@@ -253,32 +333,38 @@ class EditorModule(e:Ecology) extends QuerkiEcot(e) with Editor with querki.core
     } else
       true
   }
-  
+
   /**
    * TODO: unify this with the similar function in ThingEditor. This one is Model-oriented, though, where that is
    * Instance-oriented.
    */
-  def instancePropsForModel(model:PropertyBundle, state:SpaceState):Seq[Property[_,_]] = {
+  def instancePropsForModel(
+    model: PropertyBundle,
+    state: SpaceState
+  ): Seq[Property[_, _]] = {
     implicit val s = state
-    
-    def fromIds(propIds:Iterable[OID]):Iterable[Property[_,_]] = propIds.map(state.prop(_)).flatten
-    
-    val propsOpt = 
+
+    def fromIds(propIds: Iterable[OID]): Iterable[Property[_, _]] = propIds.map(state.prop(_)).flatten
+
+    val propsOpt =
       for {
         propsToEdit <- model.getPropOpt(InstanceProps)
         propIds = propsToEdit.v.rawList(LinkType)
-      }
-        yield fromIds(propIds)
-        
-    propsOpt.map(_.toSeq).getOrElse(fromIds(model.props.keys).filter(specialModelFilter(model, _)).toSeq.sortBy(_.displayName))
+      } yield fromIds(propIds)
+
+    propsOpt.map(_.toSeq).getOrElse(
+      fromIds(model.props.keys).filter(specialModelFilter(model, _)).toSeq.sortBy(_.displayName)
+    )
   }
-    
-  lazy val editMethod = new EditMethodBase(EditMethodOID, 
+
+  lazy val editMethod = new EditMethodBase(
+    EditMethodOID,
     toProps(
       setName("_edit"),
       Categories(EditingTag),
       Summary("Puts an editor for the specified Property into the page"),
-      Details("""Sometimes, you want to make it easy to edit a Thing, without having to go into the Editor
+      Details(
+        """Sometimes, you want to make it easy to edit a Thing, without having to go into the Editor
           |page. For instance, there may be a single button, or a few fields, that should be more easily editable
           |directly when you are looking at the Thing. That is when you use _edit.
           |
@@ -296,87 +382,96 @@ class EditorModule(e:Ecology) extends QuerkiEcot(e) with Editor with querki.core
           |needs to be designed.)
           |
           |If the current user isn't allowed to edit this Thing, _edit instead displays the ordinary, rendered value of
-          |the Property. If you want to do something else in this case, use [[_editOrElse._self]] instead.""".stripMargin),
+          |the Property. If you want to do something else in this case, use [[_editOrElse._self]] instead.""".stripMargin
+      ),
       AppliesToKindProp(Kind.Property)
-    )) 
-  {
-    def cantEditFallback(inv:Invocation):QFut = {
+    )
+  ) {
+
+    def cantEditFallback(inv: Invocation): QFut = {
       // This user isn't allowed to edit, so simply render the property in its default form.
       // For more control, user _editOrElse instead.
       for {
         prop <- inv.definingContextAsProperty
         result <- inv.fut(prop.qlApply(inv))
-      }
-        yield result
-    }  
+      } yield result
+    }
   }
-  
-  lazy val editOrElseMethod = new EditMethodBase(EditOrElseMethodOID, 
+
+  lazy val editOrElseMethod = new EditMethodBase(
+    EditOrElseMethodOID,
     toProps(
       setName("_editOrElse"),
       Categories(EditingTag),
       Summary("Like [[_edit._self]], but you can say what to show if the user can't edit this Property"),
       Details("""See [[_edit._self]] for the full details of how edit control works. This is just like that,
-          |but with an additional parameter:
-          |```
-          |THING -> PROPERTY._editOrElse(FALLBACK)
-          |```
-          |If the current user isn't allowed to edit THING, then FALLBACK is produced instead.""".stripMargin),
+                |but with an additional parameter:
+                |```
+                |THING -> PROPERTY._editOrElse(FALLBACK)
+                |```
+                |If the current user isn't allowed to edit THING, then FALLBACK is produced instead.""".stripMargin),
       AppliesToKindProp(Kind.Property)
-    )) 
-  {
-    def cantEditFallback(inv:Invocation):Future[QValue] = {
+    )
+  ) {
+
+    def cantEditFallback(inv: Invocation): Future[QValue] = {
       val context = inv.context
       val paramsOpt = inv.paramsOpt
-      
+
       // This user isn't allowed to edit, so display the fallback
       paramsOpt match {
         case Some(params) if (params.length > 0) => {
-          context.parser.get.processPhrase(params(0).firstOps, context).map(_.value)
+          context.parser.get.processor.processPhrase(params(0).firstOps, context).map(_.value)
         }
         case _ => Future.successful(QL.WarningValue("_editOrElse requires a parameter"))
       }
-    }  
+    }
   }
 
   /**
    * This is probably badly factored -- in the long run, I suspect this should actually be a param to _edit instead.
    * But this will do to start.
-   * 
+   *
    * TODO: this is weirdly incestuous with HtmlRenderer. Think about how the factoring should really work.
    */
-  lazy val editAsPicklistMethod = new EditMethodBase(EditAsPickListOID, 
+  lazy val editAsPicklistMethod = new EditMethodBase(
+    EditAsPickListOID,
     toProps(
       setName("_editAsPickList"),
       Basic.DeprecatedProp(true),
       Categories(EditingTag),
       Summary("Edits a Tag or Link Set as a Pick List"),
-      Details("""**Deprecated:** please use [[_checkList._self]] instead.
+      Details(
+        """**Deprecated:** please use [[_checkList._self]] instead.
           |
           |This is broadly similar to [[_edit._self]], but displays in a way that is sometimes more useful.
           |
           |To use _editAsPickList, your set must have Restrict to Model set. This displays all known instances of that Model
           |as a checklist, and allows you to decide what is in or out simply by checking things in the list.
           |
-          |This function will likely be replaced with a variant of _edit, so don't get too attached to it.""".stripMargin),
+          |This function will likely be replaced with a variant of _edit, so don't get too attached to it.""".stripMargin
+      ),
       AppliesToKindProp(Kind.Property)
-    )) 
-  {
+    )
+  ) {
+
     // TODO: this is stolen directly from _edit, and should probably be refactored:
-    def cantEditFallback(inv:Invocation):QFut = {
+    def cantEditFallback(inv: Invocation): QFut = {
       // This user isn't allowed to edit, so simply render the property in its default form.
       // For more control, user _editOrElse instead.
       for {
         prop <- inv.definingContextAsProperty
         result <- inv.fut(prop.qlApply(inv))
-      }
-        yield result
-    }  
-    
-    override def specialization(mainContext:QLContext, mainThing:PropertyBundle, 
-      partialContext:QLContext, prop:Property[_,_],
-      paramsOpt:Option[Seq[QLParam]]):Set[RenderSpecialization] = 
-    {
+      } yield result
+    }
+
+    override def specialization(
+      mainContext: QLContext,
+      mainThing: PropertyBundle,
+      partialContext: QLContext,
+      prop: Property[_, _],
+      paramsOpt: Option[Seq[QLParam]]
+    ): Set[RenderSpecialization] = {
       // This is basically saying "if there is one parameter, and it is the token 'withAdd'"
       // TODO: all of this should go behind a better-built parameter wrapper.
       val hasAddOpt = for (
@@ -385,119 +480,143 @@ class EditorModule(e:Ecology) extends QuerkiEcot(e) with Editor with querki.core
         param = params(0);
         QLCall(addName, _, _, _) = param.firstOps(0);
         if (addName.name.toLowerCase() == "withadd")
-          )
+      )
         yield true
-        
+
       hasAddOpt.map(_ => Set(PickList, WithAdd, FromEditFunction)).getOrElse(Set(PickList, FromEditFunction))
     }
   }
 
-	// TODO: this code is pretty damned Bootstrap-specific, which by definition is too HTML-specific. We should probably
-	// replace it with something that is much more neutral -- simple label/control styles -- and have client-side code
-	// that rewrites it appropriately for the UI in use.
-	lazy val FormLineMethod = new InternalMethod(FormLineMethodOID,
+  // TODO: this code is pretty damned Bootstrap-specific, which by definition is too HTML-specific. We should probably
+  // replace it with something that is much more neutral -- simple label/control styles -- and have client-side code
+  // that rewrites it appropriately for the UI in use.
+  lazy val FormLineMethod = new InternalMethod(
+    FormLineMethodOID,
     toProps(
       setName("_formLine"),
       Categories(EditingTag),
       SkillLevel(SkillLevelAdvanced),
       Summary("Display a label/control pair for an input form"),
-      Details("""`_formLine(LABEL,CONTROL)` displays the LABEL/CONTROL pair as a standard full-width line. 
+      Details(
+        """`_formLine(LABEL,CONTROL)` displays the LABEL/CONTROL pair as a standard full-width line. 
           |
-          |This is mainly for input forms, and is pretty persnickety at this point. It is not recommend for general use yet.""".stripMargin)))
-	{
-	  override def qlApply(inv:Invocation):QFut = {
-	    inv.paramsOpt match {
-	      case Some(params) if (params.length == 2) => {
-	        val context = inv.definingContext.get
+          |This is mainly for input forms, and is pretty persnickety at this point. It is not recommend for general use yet.""".stripMargin
+      )
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
+      inv.paramsOpt match {
+        case Some(params) if (params.length == 2) => {
+          val context = inv.definingContext.get
           for {
-            label <- context.parser.get.processPhrase(params(0).firstOps, context).map(_.value)
+            label <- context.parser.get.processor.processPhrase(params(0).firstOps, context).map(_.value)
             labelWiki <- label.wikify(context)
-            control <- context.parser.get.processPhrase(params(1).firstOps, context).map(_.value)
+            control <- context.parser.get.processor.processPhrase(params(1).firstOps, context).map(_.value)
             controlWiki <- control.wikify(context)
-          }
-	          yield QL.WikitextValue(
-  	          Wikitext("\n{{form-horizontal:\n{{control-group:\n{{control-label:\n") +
-  	          labelWiki +
-  	          Wikitext("\n}}\n{{controls:\n") +
-  	          controlWiki +
-  	          Wikitext("\n}}\n}}\n}}\n"))
-	      }
-	      case _ => QL.WarningFut("_formLine requires two parameters")
-	    }
-	  }
-	}
-  
-  lazy val CheckListMethod = new InternalMethod(CheckListOID,
+          } yield QL.WikitextValue(
+            Wikitext("\n{{form-horizontal:\n{{control-group:\n{{control-label:\n") +
+              labelWiki +
+              Wikitext("\n}}\n{{controls:\n") +
+              controlWiki +
+              Wikitext("\n}}\n}}\n}}\n")
+          )
+        }
+        case _ => QL.WarningFut("_formLine requires two parameters")
+      }
+    }
+  }
+
+  lazy val CheckListMethod = new InternalMethod(
+    CheckListOID,
     toProps(
       setName("_checkList"),
       Summary("""Display a checklist of items to add or remove from a Set."""),
       Signature(
         expected = Some(Seq(LinkType), "The items to choose from."),
-        defining = Some(true, Seq(LinkType), "The Property that actually contains the checklist, which should be a Set of Things"),
+        defining = Some(
+          true,
+          Seq(LinkType),
+          "The Property that actually contains the checklist, which should be a Set of Things"
+        ),
         reqs = Seq(
           ("on", LinkType, "The Thing that contains the Set.")
         ),
         opts = Seq(
-          ("selectedOnly", YesNoType, ExactlyOne(Logic.False), "If True, only items currently in the Set will be displayed."),
+          (
+            "selectedOnly",
+            YesNoType,
+            ExactlyOne(Logic.False),
+            "If True, only items currently in the Set will be displayed."
+          ),
           ("display", AnyType, Core.QNone, "How to display each item."),
           ("filterField", TextType, Core.QNone, "If specified, the ID of a text field to filter on"),
-          ("addModel", LinkType, Core.QNone, "If specified, you can type names in the `filterField`, and new Instances of this Model will be created")
+          (
+            "addModel",
+            LinkType,
+            Core.QNone,
+            "If specified, you can type names in the `filterField`, and new Instances of this Model will be created"
+          )
         ),
         returns = (AnyType, "The Check List, ready to display.")
       ),
-      Details("""Sometimes, you want to be able to take a Set, and use it as a checklist. The `_checkList`
-        |function is designed for that.
-        |
-        |For example, say that you have a Shopping List Space. There is a Shopping Item Model, with an Instance
-        |for each item that you sometimes shop for, and a Shops Tag Set saying where it can be found.
-        |You have a Thing named "Shopping List", with a Property "Contents", which is a Set of Things.
-        |You would display the whole shopping list, as a checklist, like this:
-        |[[```
-        |[[Shopping Item._instances -> Contents.checkList(on = Shopping List)]]
-        |```]]
-        |That is, the actual list is found in Shopping List.Contents, and you are choosing from
-        |all Instances of Shopping Item. This lets you easily add Items to the list.
-        |
-        |Sometimes, you only want to list the items that are actually checked-off. For example, when
-        |you go shopping, you just want to be checking things *off* the list. So you would say:
-        |```
-        |\[[Shopping Item._instances -> Contents._checkList(on = Shopping List, selectedOnly = true)\]]
-        |```
-        |By using `selectedOnly` like this, it will only display the currently-selected Items, so
-        |you can check them off.
-        |
-        |You can filter which items show on the list. For instance, you could show a list of just the
-        |Items to look for at Acme like this:
-        |[[```
-        |[[Shopping Item._instances
-        |  -> _filter(Shops -> _contains(Acme))
-        |  -> Contents._checkList(on = Shopping List, selectedOnly = true)]]
-        |```]]
-        |This way, you can easily display customized checklists for particular situations.
-        |
-        |You can also create a live filter-by-name. If you specify the `filterField` parameter, that should point
-        |to a _textInput that you can type into, to filter down the items being currently shown in the checklist.
-        |
-        |You can also use the `filterField` to add new items. If you add the `addModel` parameter, that specifies
-        |the model for the items in this list; if you type in a new name in the `filterField` and press Enter, a
-        |new instance of that model will be created, with the given name, and added to the checklist.
-        |
-        |So putting those together, you can specify a full shopping list, that lets you filter the items being
-        |shown and add new one on the fly, like this:
-        |[[```
-        |[[_textInput(id = ""itemfilter"", placeholder = ""Filter or add items"")]]
-        |
-        |[[Shopping Item._instances ->
-        |  Shopping Items._checkList(on = Shopping List, filterField = ""itemfilter"", addModel = Shopping Item)]]
-        |```]]
-        |
-        |By default, _checkList will display show each item's Name. But you can customize this using
-        |the `display` parameter. If provided, this will be applied to every item, and the result is
-        |what will be shown.""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+      Details(
+        """Sometimes, you want to be able to take a Set, and use it as a checklist. The `_checkList`
+          |function is designed for that.
+          |
+          |For example, say that you have a Shopping List Space. There is a Shopping Item Model, with an Instance
+          |for each item that you sometimes shop for, and a Shops Tag Set saying where it can be found.
+          |You have a Thing named "Shopping List", with a Property "Contents", which is a Set of Things.
+          |You would display the whole shopping list, as a checklist, like this:
+          |[[```
+          |[[Shopping Item._instances -> Contents.checkList(on = Shopping List)]]
+          |```]]
+          |That is, the actual list is found in Shopping List.Contents, and you are choosing from
+          |all Instances of Shopping Item. This lets you easily add Items to the list.
+          |
+          |Sometimes, you only want to list the items that are actually checked-off. For example, when
+          |you go shopping, you just want to be checking things *off* the list. So you would say:
+          |```
+          |\[[Shopping Item._instances -> Contents._checkList(on = Shopping List, selectedOnly = true)\]]
+          |```
+          |By using `selectedOnly` like this, it will only display the currently-selected Items, so
+          |you can check them off.
+          |
+          |You can filter which items show on the list. For instance, you could show a list of just the
+          |Items to look for at Acme like this:
+          |[[```
+          |[[Shopping Item._instances
+          |  -> _filter(Shops -> _contains(Acme))
+          |  -> Contents._checkList(on = Shopping List, selectedOnly = true)]]
+          |```]]
+          |This way, you can easily display customized checklists for particular situations.
+          |
+          |You can also create a live filter-by-name. If you specify the `filterField` parameter, that should point
+          |to a _textInput that you can type into, to filter down the items being currently shown in the checklist.
+          |
+          |You can also use the `filterField` to add new items. If you add the `addModel` parameter, that specifies
+          |the model for the items in this list; if you type in a new name in the `filterField` and press Enter, a
+          |new instance of that model will be created, with the given name, and added to the checklist.
+          |
+          |So putting those together, you can specify a full shopping list, that lets you filter the items being
+          |shown and add new one on the fly, like this:
+          |[[```
+          |[[_textInput(id = ""itemfilter"", placeholder = ""Filter or add items"")]]
+          |
+          |[[Shopping Item._instances ->
+          |  Shopping Items._checkList(on = Shopping List, filterField = ""itemfilter"", addModel = Shopping Item)]]
+          |```]]
+          |
+          |By default, _checkList will display show each item's Name. But you can customize this using
+          |the `display` parameter. If provided, this will be applied to every item, and the result is
+          |what will be shown.""".stripMargin
+      )
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       implicit val state = inv.state
-      
+
       for {
         selectedOnly <- inv.processAs("selectedOnly", YesNoType)
         setOID <- inv.processAs("on", LinkType)
@@ -505,63 +624,72 @@ class EditorModule(e:Ecology) extends QuerkiEcot(e) with Editor with querki.core
         modelOIDOpt <- inv.processAsOpt("addModel", LinkType)
         setThing <- inv.opt(state.anything(setOID))
         setProp <- inv.definingContextAsPropertyOf(LinkType)
-        currentPV <- inv.opt(setThing.getPropOpt(setProp), Some(new PublicException("Edit.checklist.propMissing", setThing.displayName, setProp.displayName)))
+        currentPV <- inv.opt(
+          setThing.getPropOpt(setProp),
+          Some(new PublicException("Edit.checklist.propMissing", setThing.displayName, setProp.displayName))
+        )
         currentSet = currentPV.rawList
         itemStr <- inv.fut(items(inv, currentSet, selectedOnly))
-      }
-        yield 
-          HtmlUI.HtmlValue(
-            form(
-              cls:="_checklist",
-              data.thing:=setThing.id.toThingId.toString,
-              data.prop:=setProp.id.toThingId.toString,
-              // Note that scalatags is one of the few contexts where an imbalanced if is legit:
-              if (filterField.isDefined)
-                data.filterid:=filterField.get.text,
-              if (modelOIDOpt.isDefined)
-                data.modelid:=modelOIDOpt.get.toThingId.toString,
-              ul(
-                cls:="_listContent",
-                raw(itemStr)
-              ))) 
+      } yield HtmlUI.HtmlValue(
+        form(
+          cls := "_checklist",
+          data.thing := setThing.id.toThingId.toString,
+          data.prop := setProp.id.toThingId.toString,
+          // Note that scalatags is one of the few contexts where an imbalanced if is legit:
+          if (filterField.isDefined)
+            data.filterid := filterField.get.text,
+          if (modelOIDOpt.isDefined)
+            data.modelid := modelOIDOpt.get.toThingId.toString,
+          ul(
+            cls := "_listContent",
+            raw(itemStr)
+          )
+        )
+      )
     }
-    
-    def items(inv:Invocation, currentSet:List[OID], selectedOnly:Boolean):Future[String] = {
+
+    def items(
+      inv: Invocation,
+      currentSet: List[OID],
+      selectedOnly: Boolean
+    ): Future[String] = {
       implicit val state = inv.state
       implicit val rc = inv.context.request
-      
-      val itemInv = for {  
-        elemCtx <- inv.contextElements
-        t <- inv.contextAllThings(elemCtx)
-        selected = currentSet.contains(t.id)
-        // If we're in selectedOnly, screen out items that aren't in the set:
-        if (selected || !selectedOnly)
-        displayOpt <- inv.processAsOpt("display", QL.ParsedTextType, elemCtx)
-        display <- inv.fut(displayOpt.map(d => fut(d.display)).getOrElse(t.nameOrComputed))
-      }
-        yield 
-          // For each element...
-          li(
-            // ... show the checkbox...
-            input(
-              cls:="_checkOption", 
-              value:=t.id.toThingId.toString,
-              tpe:="checkbox",
-              if (selected) checked:="checked"),
-            " ",
-            // ... and the display content
-            div(cls:="_pickName", raw(display.toString))
-          ).toString
-          
+
+      val itemInv =
+        for {
+          elemCtx <- inv.contextElements
+          t <- inv.contextAllThings(elemCtx)
+          selected = currentSet.contains(t.id)
+          // If we're in selectedOnly, screen out items that aren't in the set:
+          if (selected || !selectedOnly)
+          displayOpt <- inv.processAsOpt("display", QL.ParsedTextType, elemCtx)
+          display <- inv.fut(displayOpt.map(d => fut(d.display)).getOrElse(t.nameOrComputed))
+        } yield
+        // For each element...
+        li(
+          // ... show the checkbox...
+          input(
+            cls := "_checkOption",
+            value := t.id.toThingId.toString,
+            tpe := "checkbox",
+            if (selected) checked := "checked"
+          ),
+          " ",
+          // ... and the display content
+          div(cls := "_pickName", raw(display.toString))
+        ).toString
+
       // Turn them all into one String, to return to the main function:
       itemInv.get.map { strs =>
         if (strs.isEmpty)
           ""
         else
-          strs.toSeq.reduce(_ + _) }
+          strs.toSeq.reduce(_ + _)
+      }
     }
   }
-  
+
   override lazy val props = Seq(
     PlaceholderTextProp,
     PromptProp,

--- a/querki/scalajvm/app/querki/history/HistoryEcot.scala
+++ b/querki/scalajvm/app/querki/history/HistoryEcot.scala
@@ -64,7 +64,7 @@ class HistoryEcot(e: Ecology) extends QuerkiEcot(e) with History with querki.cor
       Summary("The standard display of the deleted Things in this Space"),
       Basic.ApplyMethod(
         """_listDeletedThings(
-          |   render=""[[Name]] ([[_oid]]) [[_QLButton(label = ""Restore"", noIcon = true, ql = _undeleteThing -> _Deleted Things -> _navigateTo)]]""
+          |   render=""[[Name]] ([[_oid]]) [[_QLButton(label = ""Restore"", noIcon = true, ql = _undeleteThing -> System Deleted Things Page -> _navigateTo)]]""
           |) -> _bulleted""".stripMargin
       )
     )
@@ -75,7 +75,7 @@ class HistoryEcot(e: Ecology) extends QuerkiEcot(e) with History with querki.cor
     systemOID,
     RootOID,
     toProps(
-      setName("_Deleted Things"),
+      setName("System Deleted Things Page"),
       Basic.DisplayTextProp("[[_deletedThingsDisplay]]")
     )
   )

--- a/querki/scalajvm/app/querki/history/HistoryEcot.scala
+++ b/querki/scalajvm/app/querki/history/HistoryEcot.scala
@@ -138,13 +138,12 @@ class HistoryEcot(e: Ecology) extends QuerkiEcot(e) with History with querki.cor
     override def qlApply(inv: Invocation): QFut = {
       for {
         rawOpt <- inv.rawParam("predicate")
-        qlText = rawOpt.map(raw => QLText(raw.reconstructStandalone))
         DeletedThings(things) <- inv.fut(
           SpaceOps.spaceRegion ?
             SpaceSubsystemRequest(
               inv.context.request.requesterOrAnon,
               inv.state.id,
-              ForAllDeletedThings(inv.context.request, qlText)
+              ForAllDeletedThings(inv.context.request, rawOpt)
             )
         )
         thing <- inv.iter(things)

--- a/querki/scalajvm/app/querki/history/HistoryEcot.scala
+++ b/querki/scalajvm/app/querki/history/HistoryEcot.scala
@@ -149,7 +149,9 @@ class HistoryEcot(e: Ecology) extends QuerkiEcot(e) with History with querki.cor
         )
         thing <- inv.iter(things)
         displayStr =
-          s"${thing.display.str} (${thing.oid.toThingId}) -- deleted ${thing.when.toString("YYYY-MM-dd hh:mma")}"
+          s"""${thing.display.str} (${thing.oid.toThingId})
+             |-- deleted ${thing.when.toString("YYYY-MM-dd hh:mma")}
+             |[[_QLButton(label=""Restore"", ql=_undeleteThing(${thing.oid.toThingId}), noIcon=true)]]""".stripMargin
         // TODO: create a more useful return display
       } yield ExactlyOne(TextType(displayStr))
     }

--- a/querki/scalajvm/app/querki/history/HistoryEcot.scala
+++ b/querki/scalajvm/app/querki/history/HistoryEcot.scala
@@ -6,9 +6,8 @@ import querki.globals._
 import querki.values.RequestContext
 import HistoryFunctions._
 import models.OID
-import querki.core.QLText
 import querki.history.SpaceHistory.{DeletedThings, ForAllDeletedThings, RestoreDeletedThing}
-import querki.ql.{ParsedQLText, QLCall, QLExp, QLThingId}
+import querki.ql.{QLCall, QLExp, QLThingId}
 import querki.spaces.messages.{SpaceSubsystemRequest, ThingFound}
 import querki.util.{ActorHelpers, PublicException}
 
@@ -166,24 +165,24 @@ class HistoryEcot(e: Ecology) extends QuerkiEcot(e) with History with querki.cor
     ListDeletedThingsOID,
     toProps(
       setName("_listDeletedThings"),
-      Summary("Lists the Things in this Space that pass the given predicate, that have been deleted."),
+      Summary("Lists the Things in this Space that pass the given filter, that have been deleted."),
       Signature(
         expected = None,
         reqs = Seq.empty,
         opts = Seq(
-          ("predicate", AnyType, Core.QNone, "A QL expression returning YesOrNoType, to try on each deleted Thing"),
+          ("filter", AnyType, Core.QNone, "A QL expression returning YesOrNoType, to try on each deleted Thing"),
           ("render", AnyType, Core.QNone, "A QL expression saying what to return from each deleted Thing")
         ),
         returns = (AnyType, "A List of resulting values from the deleting Things")
       ),
       Details(
         """
-          |If no predicate is given, all deleted Things will be returned.
+          |If no filter is given, all deleted Things will be returned.
           |
-          |The predicate can be almost anything. For example, this returns all deleted Things that are children of
+          |The filter can be almost anything. For example, this returns all deleted Things that are children of
           |`My Model`:
           |[[```
-          |_listDeletedThings(predicate = _model -> _is(My Model))
+          |_listDeletedThings(filter = _model -> _is(My Model))
           |```]]
           |
           |The `render` parameter will be applied to each deleted Thing, in the context of the history right before
@@ -191,7 +190,7 @@ class HistoryEcot(e: Ecology) extends QuerkiEcot(e) with History with querki.cor
           |renders all of the instances of `My Model`, showing the name and OID of each with "Restore" button to
           |undelete it:
           |[[```
-          |_listDeletedThings(predicate = _model -> _is(My Model), render=""[[Name]] ([[_oid]]) [[_QLButton(label = ""Restore"", noIcon = true, ql = _undeleteThing)]]"") -> _bulleted
+          |_listDeletedThings(filter = _model -> _is(My Model), render=""[[Name]] ([[_oid]]) [[_QLButton(label = ""Restore"", noIcon = true, ql = _undeleteThing)]]"") -> _bulleted
           |```]]
           |
           |If no `render` parameter is given, the OIDs of the deleted Things will be returned.""".stripMargin
@@ -201,7 +200,7 @@ class HistoryEcot(e: Ecology) extends QuerkiEcot(e) with History with querki.cor
 
     override def qlApply(inv: Invocation): QFut = {
       for {
-        predOpt <- inv.rawParam("predicate")
+        predOpt <- inv.rawParam("filter")
         renderOpt <- inv.rawParam("render")
         DeletedThings(qvs) <- inv.fut(
           SpaceOps.spaceRegion ?

--- a/querki/scalajvm/app/querki/history/HistoryEcot.scala
+++ b/querki/scalajvm/app/querki/history/HistoryEcot.scala
@@ -6,60 +6,64 @@ import querki.globals._
 import querki.values.RequestContext
 import HistoryFunctions._
 import models.OID
-import querki.history.SpaceHistory.RestoreDeletedThing
-import querki.ql.{QLExp, QLThingId, QLCall}
-import querki.spaces.messages.{ThingFound, SpaceSubsystemRequest}
-import querki.util.{PublicException, ActorHelpers}
+import querki.core.QLText
+import querki.history.SpaceHistory.{DeletedThings, ForAllDeletedThings, RestoreDeletedThing}
+import querki.ql.{ParsedQLText, QLCall, QLExp, QLThingId}
+import querki.spaces.messages.{SpaceSubsystemRequest, ThingFound}
+import querki.util.{ActorHelpers, PublicException}
 
 object MOIDs extends EcotIds(65) {
   val FindAllStompedCmdOID = moid(1)
   val HistoryPermOID = moid(2)
   val UndeleteFunctionOID = moid(3)
+  val ListDeletedThingsOID = moid(4)
 }
 
-class HistoryEcot(e:Ecology) extends QuerkiEcot(e) with History with querki.core.MethodDefs {
+class HistoryEcot(e: Ecology) extends QuerkiEcot(e) with History with querki.core.MethodDefs {
   import MOIDs._
-  
+
   val cmds = new HistoryCommands(e)
-  
+
   val AccessControl = initRequires[querki.security.AccessControl]
-  
+
   lazy val ApiRegistry = interface[querki.api.ApiRegistry]
   lazy val SpaceOps = interface[querki.spaces.SpaceOps]
 
   implicit val timeout = ActorHelpers.timeout
 
   override def postInit() = {
-    ApiRegistry.registerApiImplFor[HistoryFunctions, HistoryFunctionsImpl](SpaceOps.spaceRegion, allowedDuringHistory = true)
+    ApiRegistry
+      .registerApiImplFor[HistoryFunctions, HistoryFunctionsImpl](SpaceOps.spaceRegion, allowedDuringHistory = true)
   }
-  
-  def viewingHistoryVersion(rc:RequestContext):Option[HistoryVersion] = {
+
+  def viewingHistoryVersion(rc: RequestContext): Option[HistoryVersion] = {
     rc.rawParam("_historyVersion") match {
-      case Some(vStr) => {
+      case Some(vStr) =>
         Some(vStr.toLong)
-      }
       case _ => None
     }
   }
-  
-  def isViewingHistory(rc:RequestContext):Boolean = {
+
+  def isViewingHistory(rc: RequestContext): Boolean = {
     rc.rawParam("_historyVersion").map(_.length > 0).getOrElse(false)
   }
 
   lazy val HistoryPerm = AccessControl.definePermission(
     HistoryPermOID,
-    "Can View History", 
-    "This permission controls whether someone is allowed to examine the History of this Space. This gives full read permission!", 
+    "Can View History",
+    "This permission controls whether someone is allowed to examine the History of this Space. This gives full read permission!",
     Seq(AccessControl.OwnerTag),
     Seq(AccessControl.AppliesToSpace),
-    false, 
-    false)
+    false,
+    false
+  )
 
-  /***********************************************
-   * FUNCTIONS
-   ***********************************************/
+  ///////////////////////////////////
+  // FUNCTIONS
+  ///////////////////////////////////
 
-  lazy val UndeleteFunction = new InternalMethod(UndeleteFunctionOID,
+  lazy val UndeleteFunction = new InternalMethod(
+    UndeleteFunctionOID,
     toProps(
       setName("_undeleteThing"),
       Summary("Given the OID of a deleted Thing, restore it"),
@@ -76,9 +80,11 @@ class HistoryEcot(e:Ecology) extends QuerkiEcot(e) with History with querki.core
           |That's necessarily true (you can't pass in the OID, since the Thing doesn't exist any more).
           |
           |This is primarily intended for internal use, from the Deleted Things page.
-          |""".stripMargin)
+          |""".stripMargin
+      )
     )
   ) {
+
     // Since the Thing presumably doesn't exist in this Space currently, it would be illegal to process it in
     // the normal way -- we would get a Thing Not Found error. Instead, we have to grovel down through the
     // raw parse tree to fetch the OID itself:
@@ -88,34 +94,68 @@ class HistoryEcot(e:Ecology) extends QuerkiEcot(e) with History with querki.core
         op <- phrase.ops.headOption
         call <- op match {
           case call: QLCall => Some(call)
-          case _ => None
+          case _            => None
         }
         thingIdStr <- call.name match {
           case QLThingId(n) => Some(n)
-          case _ => None
+          case _            => None
         }
         oid <- OID.parseOpt(thingIdStr)
-      }
-        yield oid
+      } yield oid
     }
 
-    override def qlApply(inv:Invocation): QFut = {
+    override def qlApply(inv: Invocation): QFut = {
       val user = inv.context.request.requesterOrAnon
       for {
         expOpt <- inv.rawParam("oid")
         exp <- inv.opt(expOpt, Some(PublicException("History.undeleteNoOid")))
         oid <- inv.opt(expToOid(exp), Some(PublicException("History.undeleteNotOid", exp.reconstructString)))
-        ThingFound(id, newState) <-
-          inv.fut(SpaceOps.spaceRegion ?
-            SpaceSubsystemRequest(inv.context.request.requesterOrAnon, inv.state.id,
-              RestoreDeletedThing(user, oid)))
-      }
-        yield ExactlyOne(LinkType(id))
+        ThingFound(id, newState) <- inv.fut(
+          SpaceOps.spaceRegion ?
+            SpaceSubsystemRequest(inv.context.request.requesterOrAnon, inv.state.id, RestoreDeletedThing(user, oid))
+        )
+      } yield ExactlyOne(LinkType(id))
+    }
+  }
+
+  lazy val ListDeletedThings = new InternalMethod(
+    ListDeletedThingsOID,
+    toProps(
+      setName("_listDeletedThings"),
+      Summary("Lists the Things in this Space that pass the given predicate, that have been deleted."),
+      Signature(
+        expected = None,
+        reqs = Seq.empty,
+        opts = Seq(
+          ("predicate", AnyType, Core.QNone, "A QL expression returning YesOrNoType, to try on each deleted Thing")
+        ),
+        returns = (AnyType, "A List of the deleted Things")
+      ),
+      Details("""If no predicate is given, all deleted Things will be returned.""")
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
+      for {
+        rawOpt <- inv.rawParam("predicate")
+        qlText = rawOpt.map(raw => QLText(raw.reconstructStandalone))
+        DeletedThings(things) <- inv.fut(
+          SpaceOps.spaceRegion ?
+            SpaceSubsystemRequest(
+              inv.context.request.requesterOrAnon,
+              inv.state.id,
+              ForAllDeletedThings(inv.context.request, qlText)
+            )
+        )
+        thing <- inv.iter(things)
+        // TODO: create a more useful return display
+      } yield ExactlyOne(TextType(thing.display.str))
     }
   }
 
   override lazy val props = Seq(
     HistoryPerm,
-    UndeleteFunction
+    UndeleteFunction,
+    ListDeletedThings
   )
 }

--- a/querki/scalajvm/app/querki/history/HistoryEcot.scala
+++ b/querki/scalajvm/app/querki/history/HistoryEcot.scala
@@ -16,7 +16,7 @@ object MOIDs extends EcotIds(65) {
   val FindAllStompedCmdOID = moid(1)
   val HistoryPermOID = moid(2)
   val UndeleteFunctionOID = moid(3)
-  val ListDeletedThingsOID = moid(4)
+  val ShowDeletedThingsOID = moid(4)
 }
 
 class HistoryEcot(e: Ecology) extends QuerkiEcot(e) with History with querki.core.MethodDefs {
@@ -118,18 +118,18 @@ class HistoryEcot(e: Ecology) extends QuerkiEcot(e) with History with querki.cor
     }
   }
 
-  lazy val ListDeletedThings = new InternalMethod(
-    ListDeletedThingsOID,
+  lazy val ShowDeletedThings = new InternalMethod(
+    ShowDeletedThingsOID,
     toProps(
-      setName("_listDeletedThings"),
-      Summary("Lists the Things in this Space that pass the given predicate, that have been deleted."),
+      setName("_showDeletedThings"),
+      Summary("Shows the Things in this Space that pass the given predicate, that have been deleted."),
       Signature(
         expected = None,
         reqs = Seq.empty,
         opts = Seq(
           ("predicate", AnyType, Core.QNone, "A QL expression returning YesOrNoType, to try on each deleted Thing")
         ),
-        returns = (AnyType, "A List of the deleted Things")
+        returns = (TextType, "A List of Text entries for the deleted Things")
       ),
       Details("""If no predicate is given, all deleted Things will be returned.""")
     )
@@ -148,14 +148,16 @@ class HistoryEcot(e: Ecology) extends QuerkiEcot(e) with History with querki.cor
             )
         )
         thing <- inv.iter(things)
+        displayStr =
+          s"${thing.display.str} (${thing.oid.toThingId}) -- deleted ${thing.when.toString("YYYY-MM-dd hh:mma")}"
         // TODO: create a more useful return display
-      } yield ExactlyOne(TextType(thing.display.str))
+      } yield ExactlyOne(TextType(displayStr))
     }
   }
 
   override lazy val props = Seq(
     HistoryPerm,
     UndeleteFunction,
-    ListDeletedThings
+    ShowDeletedThings
   )
 }

--- a/querki/scalajvm/app/querki/history/SpaceHistory.scala
+++ b/querki/scalajvm/app/querki/history/SpaceHistory.scala
@@ -309,7 +309,8 @@ private[history] class SpaceHistory(
             val (soFar, prevState) = v
             val HistoryRecord(_, evt, state) = record
             evt match {
-              case DHDeleteThing(req, thingId, modTime) => {
+              // Only worry about deletion events for things that have not been subsequently restored:
+              case DHDeleteThing(req, thingId, modTime) if (history.last.state.anything(thingId).isEmpty) => {
                 // Evaluate the predicate on this thing in the context of the *previous* state, when the
                 // Thing still existed:
                 val endTime = ecology.api[querki.time.TimeProvider].qlEndTime

--- a/querki/scalajvm/app/querki/history/SpaceHistory.scala
+++ b/querki/scalajvm/app/querki/history/SpaceHistory.scala
@@ -15,24 +15,31 @@ import querki.history.HistoryFunctions._
 import querki.history.SpaceHistory._
 import querki.identity.User
 import querki.identity.IdentityPersistence.UserRef
-import querki.spaces.{TracingSpace, SpacePure}
+import querki.spaces.{SpacePure, TracingSpace}
 import querki.spaces.messages._
 import querki.spaces.SpaceMessagePersistence._
 import querki.time._
-import querki.util.{PublicException, SingleRoutingParent, QuerkiActor, TimeoutChild}
-import querki.values.{SpaceVersion, SpaceState, RequestContext}
+import querki.util.{PublicException, QuerkiActor, SingleRoutingParent, TimeoutChild}
+import querki.values.{QLContext, QValue, RequestContext, SpaceState, SpaceVersion}
 import HistoryFunctions._
-import akka.persistence.query.scaladsl.{ReadJournal, CurrentEventsByPersistenceIdQuery}
+import akka.persistence.query.scaladsl.{CurrentEventsByPersistenceIdQuery, ReadJournal}
+import querki.core.QLText
 
 /**
  * This is a very simplistic wrapper around SpaceHistory, so that the latter can only be in
  * memory when needed. It routes all messages to SpaceHistory.
- * 
+ *
  * This lives under SpaceRouter, as part of the standard troupe.
  */
-class SpaceHistoryParent(e:Ecology, val id:OID, val spaceRouter:ActorRef) extends Actor with ReceivePipeline with SingleRoutingParent {
-  def createChild():ActorRef = context.actorOf(Props(classOf[SpaceHistory], e, id, spaceRouter))
-  
+class SpaceHistoryParent(
+  e: Ecology,
+  val id: OID,
+  val spaceRouter: ActorRef
+) extends Actor
+     with ReceivePipeline
+     with SingleRoutingParent {
+  def createChild(): ActorRef = context.actorOf(Props(classOf[SpaceHistory], e, id, spaceRouter))
+
   def receive = {
     case msg => routeToChild(msg)
   }
@@ -42,18 +49,29 @@ class SpaceHistoryParent(e:Ecology, val id:OID, val spaceRouter:ActorRef) extend
  * This is essentially a variant of the PersistentSpaceActor, which reads in the complete history
  * of a Space, and provides access to it.
  */
-private [history] class SpaceHistory(e:Ecology, val id:OID, val spaceRouter:ActorRef) 
-  extends QuerkiActor(e) with SpacePure with ModelPersistence with ReceivePipeline with TimeoutChild
-{
+private[history] class SpaceHistory(
+  e: Ecology,
+  val id: OID,
+  val spaceRouter: ActorRef
+) extends QuerkiActor(e)
+     with SpacePure
+     with ModelPersistence
+     with ReceivePipeline
+     with TimeoutChild {
   lazy val Basic = interface[querki.basic.Basic]
   lazy val ClientApi = interface[querki.api.ClientApi]
   lazy val Core = interface[querki.core.Core]
   lazy val IdentityAccess = interface[querki.identity.IdentityAccess]
   lazy val Person = interface[querki.identity.Person]
+  lazy val QL = interface[querki.ql.QL]
   lazy val SystemState = interface[querki.system.System].State
-  
-  def timeoutConfig:String = "querki.history.timeout"
-  
+
+  lazy val ExactlyOne = Core.ExactlyOne
+  lazy val LinkType = Core.LinkType
+  lazy val YesNoType = Core.YesNoType
+
+  def timeoutConfig: String = "querki.history.timeout"
+
   def persistenceId = id.toThingId.toString
 
   lazy val tracing = TracingSpace(id, "SpaceHistory: ")
@@ -62,47 +80,62 @@ private [history] class SpaceHistory(e:Ecology, val id:OID, val spaceRouter:Acto
   // likely with machinery to override Ecology members. But it'll do for now.
   lazy val test =
     Config.getString("akka.persistence.journal.plugin") == "inmemory-journal"
-  
+
   lazy val readJournal: ReadJournal with CurrentEventsByPersistenceIdQuery =
     if (test)
       // During tests, we are using the in-memory journal. Yes, this is the documented way to do it:
       //   https://github.com/dnvriend/akka-persistence-inmemory
-      PersistenceQuery(context.system).readJournalFor("inmemory-read-journal").asInstanceOf[ReadJournal with CurrentEventsByPersistenceIdQuery]
+      PersistenceQuery(context.system)
+        .readJournalFor("inmemory-read-journal")
+        .asInstanceOf[ReadJournal with CurrentEventsByPersistenceIdQuery]
     else
       PersistenceQuery(context.system).readJournalFor[CassandraReadJournal](CassandraReadJournal.Identifier)
 
-  case class HistoryRecord(sequenceNr:Long, evt:SpaceEvent, state:SpaceState)
+  case class HistoryRecord(
+    sequenceNr: Long,
+    evt: SpaceEvent,
+    state: SpaceState
+  )
   type StateHistory = Vector[HistoryRecord]
   val StateHistory = Vector
-  
+
   // The full history of this Space, *one*-indexed. (That seems to be the way Akka Persistence works.)
   // Be careful using this: the 1-indexing isn't at all obvious.
   // TODO: if we start to cope with extracting slices of the history, we'll need to maintain the
   // base index. Note that we can count on sequenceNr increasing monotonically (per discussion in
   // akka-persistence-cassandra Gitter, 9/13/16), so using a Vector makes sense here.
   var history = StateHistory.empty[HistoryRecord]
-  
+
   def latestState = history.lastOption.map(_.state).getOrElse(emptySpace)
-  
-  implicit def OID2TID(oid:OID):TID = ClientApi.OID2TID(oid)
-  
-  def toSummary(evt:SpaceEvent, sequenceNr:Long, identities:Set[OID], allThingIds:Set[OID])(implicit state:SpaceState):(EvtSummary, Set[OID], Set[OID]) = 
-  {
-    def fill(userRef:UserRef, thingIds:Seq[OID], f:String => EvtSummary):(EvtSummary, Set[OID], Set[OID]) = {
+
+  implicit def OID2TID(oid: OID): TID = ClientApi.OID2TID(oid)
+
+  def toSummary(
+    evt: SpaceEvent,
+    sequenceNr: Long,
+    identities: Set[OID],
+    allThingIds: Set[OID]
+  )(implicit
+    state: SpaceState
+  ): (EvtSummary, Set[OID], Set[OID]) = {
+    def fill(
+      userRef: UserRef,
+      thingIds: Seq[OID],
+      f: String => EvtSummary
+    ): (EvtSummary, Set[OID], Set[OID]) = {
       val summary = f(userRef.identityIdOpt.map(_.toThingId.toString).getOrElse(""))
-      
+
       val newIdentities = userRef.identityIdOpt match {
         case Some(identityId) => identities + identityId
-        case None => identities
+        case None             => identities
       }
-      
+
       val namePairs = for {
         thingId <- thingIds
         thing <- state.anything(thingId)
-      }
-        yield (thingId, thing.displayName)
-        
-      val newThingIds = 
+      } yield (thingId, thing.displayName)
+
+      val newThingIds =
         (allThingIds /: namePairs) { (tn, pair) =>
           val (id, name) = pair
           tn + id
@@ -110,39 +143,50 @@ private [history] class SpaceHistory(e:Ecology, val id:OID, val spaceRouter:Acto
 
       (summary, newIdentities, newThingIds)
     }
-    
+
     evt match {
-      case DHSetState(dh, modTime, reason, details) => 
-        (SetStateSummary(
-          sequenceNr, 
-          "", 
-          modTime.toTimestamp, 
-          SetStateReason.withValue(reason.getOrElse(0)),
-          details.getOrElse("")), 
-        identities, 
-        allThingIds)
-      
+      case DHSetState(dh, modTime, reason, details) =>
+        (
+          SetStateSummary(
+            sequenceNr,
+            "",
+            modTime.toTimestamp,
+            SetStateReason.withValue(reason.getOrElse(0)),
+            details.getOrElse("")
+          ),
+          identities,
+          allThingIds
+        )
+
       case DHInitState(userRef, display) => fill(userRef, Seq.empty, ImportSummary(sequenceNr, _, 0))
-      
-      case DHCreateThing(req, thingId, kind, modelId, dhProps, modTime, restored) => 
-        fill(req, dhProps.keys.toSeq :+ thingId, CreateSummary(sequenceNr, _, modTime.toTimestamp, kind, thingId, modelId, restored.getOrElse(false)))
-      
-      case DHModifyThing(req, thingId, modelIdOpt, propChanges, replaceAllProps, modTime) => 
-        fill(req, propChanges.keys.toSeq :+ thingId, ModifySummary(sequenceNr, _, modTime.toTimestamp, thingId, propChanges.keys.toSeq.map(OID2TID)))
-      
-      case DHDeleteThing(req, thingId, modTime) => 
+
+      case DHCreateThing(req, thingId, kind, modelId, dhProps, modTime, restored) =>
+        fill(
+          req,
+          dhProps.keys.toSeq :+ thingId,
+          CreateSummary(sequenceNr, _, modTime.toTimestamp, kind, thingId, modelId, restored.getOrElse(false))
+        )
+
+      case DHModifyThing(req, thingId, modelIdOpt, propChanges, replaceAllProps, modTime) =>
+        fill(
+          req,
+          propChanges.keys.toSeq :+ thingId,
+          ModifySummary(sequenceNr, _, modTime.toTimestamp, thingId, propChanges.keys.toSeq.map(OID2TID))
+        )
+
+      case DHDeleteThing(req, thingId, modTime) =>
         fill(req, Seq(thingId), DeleteSummary(sequenceNr, _, modTime.toTimestamp, thingId))
-        
+
       case DHAddApp(req, modTime, app, appParents, shadowMapping, _) =>
         fill(req, Seq(app.id), AddAppSummary(sequenceNr, _, modTime.toTimestamp, app.id))
     }
   }
-  
+
   /**
    * This reads all of the history since the last time it was called. It is designed so that we can
    * reload the client page and get any new events since it was last shown.
    */
-  def readCurrentHistory():RequestM[Unit] = {
+  def readCurrentHistory(): RequestM[Unit] = {
     tracing.trace("readCurrentHistory")
     // TODO: this is utterly *profligate* with RAM. Think about how we might want to restructure this in
     // order to not hold the entire thing in memory all the time, while still providing reasonably
@@ -159,34 +203,40 @@ private [history] class SpaceHistory(e:Ecology, val id:OID, val spaceRouter:Acto
       // Note that we construct the history using VectorBuilder, for efficiency:
       source.runFold((initialState, new VectorBuilder[HistoryRecord])) {
         // Note that this quite intentionally rejects anything that isn't a SpaceEvent!
-        case (((curState, history), EventEnvelope(offset, persistenceId, sequenceNr, evt:SpaceEvent))) =>
-        val nextState = evolveState(Some(curState))(evt)
-        history += HistoryRecord(sequenceNr, evt, nextState)
-        (nextState, history)
+        case (((curState, history), EventEnvelope(offset, persistenceId, sequenceNr, evt: SpaceEvent))) => {
+          val nextState = evolveState(Some(curState))(evt)
+          history += HistoryRecord(sequenceNr, evt, nextState)
+          (nextState, history)
+        }
       }
-    } map { fullHist =>
+    }.map { fullHist =>
       history = history ++ fullHist._2.result
       mat.shutdown()
-    }    
+    }
   }
-  
+
   /**
    * Run through the OIDs needed for the History, and get their Names. We have to do this in a
    * second pass because, in order to cope with Computed Names, this needs to be done with Future.
    */
-  def mapNames(ids:Set[OID])(implicit rc:RequestContext, state:SpaceState):Future[ThingNames] = {
+  def mapNames(
+    ids: Set[OID]
+  )(implicit
+    rc: RequestContext,
+    state: SpaceState
+  ): Future[ThingNames] = {
     (Future.successful(Map.empty[TID, String]) /: ids) { (fut, id) =>
       fut.flatMap { m =>
         state.anything(id) match {
           case Some(t) => t.nameOrComputed.map(name => m + (OID2TID(id) -> name))
-          case _ => Future.successful(m)
+          case _       => Future.successful(m)
         }
       }
     }
   }
-  
-  def getHistoryRecord(v:HistoryVersion):RequestM[HistoryRecord] = {
-    readCurrentHistory() map { _ =>
+
+  def getHistoryRecord(v: HistoryVersion): RequestM[HistoryRecord] = {
+    readCurrentHistory().map { _ =>
       if (history.size < v)
         // TODO: ugly, but this *is* conceptually an internal error. Is there anything smarter
         // we can/should do here?
@@ -198,13 +248,13 @@ private [history] class SpaceHistory(e:Ecology, val id:OID, val spaceRouter:Acto
       }
     }
   }
-  
+
   /**
    * This finds and returns all of the "stomped" records due to the damned duplicate-OID bug.
    * It simply runs through the History, looking for Create events for which there is already
    * a record in the Space.
    */
-  def findAllStomped():RequestM[List[OneStompedThing]] = {
+  def findAllStomped(): RequestM[List[OneStompedThing]] = {
     // TODO: this is utterly *profligate* with RAM. Think about how we might want to restructure this in
     // order to not hold the entire thing in memory all the time, while still providing reasonably
     // responsive access. Should we instead rebuild stuff on-demand? Should the client signal what
@@ -215,66 +265,130 @@ private [history] class SpaceHistory(e:Ecology, val id:OID, val spaceRouter:Acto
       // Note that we construct the history using VectorBuilder, for efficiency:
       source.runFold((emptySpace, List.empty[OneStompedThing])) {
         // Note that this quite intentionally rejects anything that isn't a SpaceEvent!
-        case (((curState, stomped), EventEnvelope(offset, persistenceId, sequenceNr, evt:SpaceEvent))) => {
+        case (((curState, stomped), EventEnvelope(offset, persistenceId, sequenceNr, evt: SpaceEvent))) => {
           val nextStomped = evt match {
-            case DHCreateThing(req, thingId, kind, modelId, dhProps, modTime, restored) 
-                 if (curState.anything(thingId).isDefined) =>
-                   OneStompedThing(sequenceNr, thingId, curState.anything(thingId).get.displayName) :: stomped
+            case DHCreateThing(req, thingId, kind, modelId, dhProps, modTime, restored)
+                if (curState.anything(thingId).isDefined) =>
+              OneStompedThing(sequenceNr, thingId, curState.anything(thingId).get.displayName) :: stomped
             case _ => stomped
           }
           val nextState = evolveState(Some(curState))(evt)
           (nextState, nextStomped)
         }
       }
-    } map { case (finalState, stompedList) =>
-      mat.shutdown()
-      stompedList.reverse
+    }.map {
+      case (finalState, stompedList) =>
+        mat.shutdown()
+        stompedList.reverse
     }
   }
-  
+
+  // Copied from YesNoUtils
+  // TODO: refactor YesNoUtils so that it doesn't require being mixed in with an Ecot. The challenge is
+  // that the Ecot definition of Core isn't precisely the same as the definition here, because it is an
+  // initRequires -- it *acts* the same, but it's a different type. We we need a concept of "a way to get
+  // at Core".
+  def toBoolean(typed: QValue): Boolean = {
+    if (typed.pType == YesNoType)
+      typed.firstAs(YesNoType).getOrElse(false)
+    else
+      false
+  }
+
+  // No reason to get RequestM involved here, since it's all local processing -- just use Future.
+  // TODO: someday, once we have rewritten the stack to use IO, this should be much, much faster:
+  def findAllDeleted(
+    rc: RequestContext,
+    predicateOpt: Option[QLText]
+  ): Future[List[OneDeletedThing]] = {
+    val predicate = predicateOpt.getOrElse(QLText("True"))
+    readCurrentHistory().flatMap { _ =>
+      history
+        .foldLeft(Future.successful((List.empty[OneDeletedThing], emptySpace))) { (requestM, record) =>
+          requestM.flatMap { v =>
+            val (soFar, prevState) = v
+            val HistoryRecord(_, evt, state) = record
+            evt match {
+              case DHDeleteThing(req, thingId, modTime) => {
+                // Evaluate the predicate on this thing in the context of the *previous* state, when the
+                // Thing still existed:
+                val endTime = ecology.api[querki.time.TimeProvider].qlEndTime
+                val context = QLContext(ExactlyOne(LinkType(thingId)), Some(rc), endTime)(prevState, ecology)
+                QL.processMethod(predicate, context).flatMap { qv =>
+                  if (toBoolean(qv)) {
+                    // Passes the predicate, so figure out its name, and add it to the list:
+                    prevState.resolveOpt(thingId)(_.things).map { thing =>
+                      thing.nameOrComputed(rc, prevState).map { name =>
+                        val deleted = OneDeletedThing(thingId, name, evt.modTime)
+                        ((deleted :: soFar, state))
+                      }
+                    }.getOrElse {
+                      // Oddly, we didn't find that OID in the previous state, so give up and show the raw OID:
+                      val deleted = OneDeletedThing(thingId, DisplayText(thingId.toThingId), evt.modTime)
+                      Future.successful((deleted :: soFar, state))
+                    }
+                  } else {
+                    // Didn't pass the predicate, so just keep going:
+                    Future.successful((soFar, state))
+                  }
+                }
+              }
+
+              // Anything other than deletions is ignored -- move along...
+              case _ => Future.successful((soFar, state))
+            }
+          }
+        }
+        .map(_._1)
+    }
+  }
+
   def doReceive = {
     case GetHistorySummary(rc) => {
       tracing.trace(s"GetHistorySummary")
       readCurrentHistory().map { _ =>
-        val (evtsBuilder, identityIds, thingIds) = ((new VectorBuilder[EvtSummary], Set.empty[OID], Set.empty[OID]) /: history) { (current, historyRec) =>
-          val (builder, identities, thingIds) = current
-          val (summary, newIdentities, newThingIds) = toSummary(historyRec.evt, historyRec.sequenceNr, identities, thingIds)(historyRec.state)
-          (builder += summary, newIdentities, newThingIds)
-        }
-        
-        val namesFut:Future[ThingNames] = mapNames(thingIds)(rc, latestState)
+        val (evtsBuilder, identityIds, thingIds) =
+          ((new VectorBuilder[EvtSummary], Set.empty[OID], Set.empty[OID]) /: history) { (current, historyRec) =>
+            val (builder, identities, thingIds) = current
+            val (summary, newIdentities, newThingIds) =
+              toSummary(historyRec.evt, historyRec.sequenceNr, identities, thingIds)(historyRec.state)
+            (builder += summary, newIdentities, newThingIds)
+          }
+
+        val namesFut: Future[ThingNames] = mapNames(thingIds)(rc, latestState)
         val identityFut = IdentityAccess.getIdentities(identityIds.toSeq)
-        
+
         for {
           thingNames <- loopback(namesFut)
           identities <- loopback(identityFut)
-          identityMap = identities.map { case (id, publicIdentity) =>
-            (id.toThingId.toString -> ClientApi.identityInfo(publicIdentity))
+          identityMap = identities.map {
+            case (id, publicIdentity) =>
+              (id.toThingId.toString -> ClientApi.identityInfo(publicIdentity))
           }
-        }
-          sender ! HistorySummary(evtsBuilder.result, EvtContext(identityMap, thingNames))
+        } sender ! HistorySummary(evtsBuilder.result, EvtContext(identityMap, thingNames))
       }
     }
-    
+
     case GetHistoryVersion(v) => {
       tracing.trace("GetHistoryVersion")
-      getHistoryRecord(v) map { record =>
+      getHistoryRecord(v).map { record =>
         sender ! CurrentState(record.state)
       }
     }
-    
+
     case RollbackTo(v, user) => {
       tracing.trace(s"RollbackTo($v)")
-      getHistoryRecord(v) map { record =>
-        spaceRouter.request(SetState(user, id, record.state, SetStateReason.RolledBack, v.toString)) foreach {
+      getHistoryRecord(v).map { record =>
+        spaceRouter.request(SetState(user, id, record.state, SetStateReason.RolledBack, v.toString)).foreach {
           _ match {
-            case resp:ThingFound => sender ! resp
-            case other => throw new Exception(s"Tried to roll space $id back to version $v, but received response $other")
+            case resp: ThingFound => sender ! resp
+            case other =>
+              throw new Exception(s"Tried to roll space $id back to version $v, but received response $other")
           }
         }
       }
     }
-    
+
     case RestoreDeletedThing(user, thingId) => {
       tracing.trace(s"RestoreDeletedThing($thingId)")
       readCurrentHistory().map { _ =>
@@ -284,23 +398,23 @@ private [history] class SpaceHistory(e:Ecology, val id:OID, val spaceRouter:Acto
             // We don't need to do anything, because it's not currently deleted
             sender ! ThingFound(thingId, history.last.state)
           }
-          
+
           case None => {
             // The normal case: it's not there
             // Seek backwards through the History until we find this Thing.
             // There might be an abstraction fighting to break out here: keep an eye open for
             // other functions that want this "look backwards until" behavior.
             @annotation.tailrec
-            def findThingRec(index:Int):Option[Thing] = {
+            def findThingRec(index: Int): Option[Thing] = {
               if (index < 0)
                 None
               else
                 history(index).state.anything(thingId) match {
                   case Some(thing) => Some(thing)
-                  case None => findThingRec(index - 1)
+                  case None        => findThingRec(index - 1)
                 }
             }
-            
+
             findThingRec(history.size - 1) match {
               case Some(thing) => {
                 val createMsg =
@@ -314,9 +428,10 @@ private [history] class SpaceHistory(e:Ecology, val id:OID, val spaceRouter:Acto
                     creatorOpt = thing.creatorOpt,
                     createTimeOpt = thing.createTimeOpt
                   )
-                spaceRouter.request(createMsg) foreach {
-                  case resp:ThingFound => sender ! resp
-                  case other => throw new Exception(s"RestoreDeletedThing, in Space $id, for Thing $thingId, got response $other!")
+                spaceRouter.request(createMsg).foreach {
+                  case resp: ThingFound => sender ! resp
+                  case other =>
+                    throw new Exception(s"RestoreDeletedThing, in Space $id, for Thing $thingId, got response $other!")
                 }
               }
               case None => throw new Exception(s"RestoreDeletedThing couldn't find Thing $thingId!")
@@ -325,7 +440,7 @@ private [history] class SpaceHistory(e:Ecology, val id:OID, val spaceRouter:Acto
         }
       }
     }
-    
+
     case FindAllStomped() => {
       tracing.trace(s"FindAllStomped")
       findAllStomped().map { stompedList =>
@@ -343,11 +458,24 @@ private [history] class SpaceHistory(e:Ecology, val id:OID, val spaceRouter:Acto
         sender ! SpaceBlocked(PublicException("Space.blocked"))
       }
     }
+
+    case ForAllDeletedThings(rc, predicateOpt) => {
+      loopback(findAllDeleted(rc, predicateOpt)).map { deletedList =>
+        sender ! DeletedThings(deletedList)
+      }.recover {
+        case ex: Exception => spew(s"Got an Exception: $ex")
+      }
+    }
   }
 }
 
 object SpaceHistory {
-  def actorProps(e:Ecology, id:OID, spaceRouter:ActorRef) = Props(classOf[SpaceHistoryParent], e, id, spaceRouter)
+
+  def actorProps(
+    e: Ecology,
+    id: OID,
+    spaceRouter: ActorRef
+  ) = Props(classOf[SpaceHistoryParent], e, id, spaceRouter)
 
   /**
    * Note that HistoryMessages *can* be used as a SpaceMessagePayload, but mostly are routed directly.
@@ -359,29 +487,40 @@ object SpaceHistory {
   /**
    * Fetches the HistorySummary (as described in the public API).
    */
-  case class GetHistorySummary(rc:RequestContext) extends HistoryMessage
-  
+  case class GetHistorySummary(rc: RequestContext) extends HistoryMessage
+
   /**
    * Fetch a specific version of the history of this Space. Returns a CurrentState().
    */
-  case class GetHistoryVersion(v:HistoryVersion) extends HistoryMessage
-  
+  case class GetHistoryVersion(v: HistoryVersion) extends HistoryMessage
+
   /**
    * Resets the current state of this Space to the specified Version.
-   * 
+   *
    * The caller is expected to have already done confirmation! This doesn't precisely lose
    * information, but can hide a lot!
    */
-  case class RollbackTo(v:HistoryVersion, user:User) extends HistoryMessage
-  
+  case class RollbackTo(
+    v: HistoryVersion,
+    user: User
+  ) extends HistoryMessage
+
   /**
    * Finds the last existing revision of the specified Thing, and re-creates it in this Space.
    */
-  case class RestoreDeletedThing(user:User, thingId:OID) extends HistoryMessage
-  
+  case class RestoreDeletedThing(
+    user: User,
+    thingId: OID
+  ) extends HistoryMessage
+
   case class FindAllStomped() extends HistoryMessage
-  case class OneStompedThing(event:Long, oid:OID, display:String)
-  case class StompedThings(things:List[OneStompedThing])
+
+  case class OneStompedThing(
+    event: Long,
+    oid: OID,
+    display: String
+  )
+  case class StompedThings(things: List[OneStompedThing])
 
   /**
    * Return the current State.
@@ -391,4 +530,22 @@ object SpaceHistory {
    * admin use only, mainly for forensics.
    */
   case class GetCurrentState(rc: RequestContext) extends HistoryMessage
+
+  /**
+   * Looks for all of the deleted Things in the Space that match the given QL predicate at the time when they
+   * were deleted. Returns them as a [[DeletedThings]] message.
+   *
+   * @param predicate a QL expression that should return YesOrNo; if missing, all deleted Things are returned
+   */
+  case class ForAllDeletedThings(
+    rc: RequestContext,
+    predicate: Option[QLText]
+  ) extends HistoryMessage
+
+  case class OneDeletedThing(
+    oid: OID,
+    display: DisplayText,
+    when: DateTime
+  )
+  case class DeletedThings(things: List[OneDeletedThing])
 }

--- a/querki/scalajvm/app/querki/html/UIModule.scala
+++ b/querki/scalajvm/app/querki/html/UIModule.scala
@@ -25,7 +25,7 @@ object UIMOIDs extends EcotIds(11) {
   val CreateInstanceLinkOID = sysId(69)
   val ShowLinkMethodOID = sysId(95)
   val PropLinkMethodOID = sysId(96)
-  
+
   val ClassMethodOID = moid(1)
   val TooltipMethodOID = moid(2)
   val DataMethodOID = moid(3)
@@ -50,7 +50,7 @@ object UIMOIDs extends EcotIds(11) {
  * TODO: this should probably be merged with HtmlRenderer -- the distinction between them looks pretty
  * artificial from the outside.
  */
-class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.MethodDefs {
+class UIModule(e: Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.MethodDefs {
   import UIMOIDs._
 
   val Basic = initRequires[querki.basic.Basic]
@@ -60,94 +60,129 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
   lazy val PublicUrls = interface[PublicUrls]
   val QL = initRequires[querki.ql.QL]
   lazy val Tags = interface[querki.tags.Tags]
-  
+
   lazy val ExternalLinkType = Links.URLType
   lazy val NewTagSetType = Tags.NewTagSetType
   lazy val ParsedTextType = QL.ParsedTextType
 
-  /***********************************************
+  /**
+   * *********************************************
    * TYPES
-   ***********************************************/
+   * *********************************************
+   */
 
   /**
    * This is a fake PType, so that code can inject HTML into the pipeline.
-   * 
+   *
    * The odd name is because this is effectively an error in some cases: it shows up when, for instance,
    * you have a Required Thing that points to -1.
    */
-  lazy val RawHtmlType = new SystemType[Wikitext](UnknownOID, 
+  lazy val RawHtmlType = new SystemType[Wikitext](
+    UnknownOID,
     toProps(
       setName("Value has not been set"),
       setInternal,
-      Basic.DisplayTextProp("""This shows up when you have a Required Property (usually a Required Thing)
-        |or a List Element
-        |that hasn't actually been set to a value. Set the Property to something real in order to make this
-        |message go away.
-        |
-        |(If you never want to see this message, set the Property to a default value in its Model.)
-        """.stripMargin))) with SimplePTypeBuilder[Wikitext]
-  {
-    def doDeserialize(v:String)(implicit state:SpaceState) = throw new Exception("Can't deserialize ParsedText!")
-    def doSerialize(v:Wikitext)(implicit state:SpaceState) = throw new Exception("Can't serialize ParsedText!")
-    def doWikify(context:QLContext)(v:Wikitext, displayOpt:Option[Wikitext] = None, lexicalThing:Option[PropertyBundle] = None) = 
+      Basic.DisplayTextProp(
+        """This shows up when you have a Required Property (usually a Required Thing)
+          |or a List Element
+          |that hasn't actually been set to a value. Set the Property to something real in order to make this
+          |message go away.
+          |
+          |(If you never want to see this message, set the Property to a default value in its Model.)
+        """.stripMargin
+      )
+    )
+  ) with SimplePTypeBuilder[Wikitext] {
+    def doDeserialize(v: String)(implicit state: SpaceState) = throw new Exception("Can't deserialize ParsedText!")
+    def doSerialize(v: Wikitext)(implicit state: SpaceState) = throw new Exception("Can't serialize ParsedText!")
+
+    def doWikify(
+      context: QLContext
+    )(
+      v: Wikitext,
+      displayOpt: Option[Wikitext] = None,
+      lexicalThing: Option[PropertyBundle] = None
+    ) =
       Future.successful(v)
-    
-    def doDefault(implicit state:SpaceState) = Wikitext("")
-    
+
+    def doDefault(implicit state: SpaceState) = Wikitext("")
+
     // Transient values, so we don't care:
-    def doComputeMemSize(v:Wikitext):Int = 0
+    def doComputeMemSize(v: Wikitext): Int = 0
   }
 
-  def HtmlValue(html:QHtml):QValue = ExactlyOne(RawHtmlType(HtmlWikitext(html)))
-  def HtmlValue(str:String):QValue = HtmlValue(QHtml(str))
-  def HtmlValue(xml:NodeSeq):QValue = HtmlValue(Xhtml.toXhtml(xml))
-  def HtmlValue(tag:TypedTag[_]):QValue = ExactlyOne(RawHtmlType(HtmlWikitext(tag.toString)))
-  
-  def toWikitext(xml:NodeSeq):Wikitext = HtmlWikitext(QHtml(Xhtml.toXhtml(xml)))
-  
+  def HtmlValue(html: QHtml): QValue = ExactlyOne(RawHtmlType(HtmlWikitext(html)))
+  def HtmlValue(str: String): QValue = HtmlValue(QHtml(str))
+  def HtmlValue(xml: NodeSeq): QValue = HtmlValue(Xhtml.toXhtml(xml))
+  def HtmlValue(tag: TypedTag[_]): QValue = ExactlyOne(RawHtmlType(HtmlWikitext(tag.toString)))
+
+  def toWikitext(xml: NodeSeq): Wikitext = HtmlWikitext(QHtml(Xhtml.toXhtml(xml)))
+
   override lazy val types = Seq(
     RawHtmlType
   )
 
-  /***********************************************
+  /**
+   * *********************************************
    * THINGS
-   ***********************************************/
+   * *********************************************
+   */
 
-  lazy val OwnedThingsPage = ThingState(OwnedThingsPageOID, systemOID, RootOID,
+  lazy val OwnedThingsPage = ThingState(
+    OwnedThingsPageOID,
+    systemOID,
+    RootOID,
     toProps(
       setName("_ownedThingsPage"),
       PageHeaderProperty("# Things owned by [[$person]]"),
       setInternal,
       Basic.DisplayTextProp(
-        """[[$person -> _ownedThings -> _bulleted]]""".stripMargin)
-    ))
+        """[[$person -> _ownedThings -> _bulleted]]""".stripMargin
+      )
+    )
+  )
 
   override lazy val things = Seq(
     OwnedThingsPage
   )
 
-  /***********************************************
+  /**
+   * *********************************************
    * PROPERTIES
-   ***********************************************/
-  
+   * *********************************************
+   */
+
   /**
    * This is the abstraction of a single-parameter function that takes some HTML and modifies it. It is
    * mainly intended for use with functions that change the attributes of the HTML.
    */
-  abstract class HtmlModifier(oid:OID, name:String, summary:String, details:String) extends InternalMethod(oid, 
-    toProps(
-      setName(name),
-      Categories(UITag),
-      Summary(summary),
-      Details(details))) 
-  {
+  abstract class HtmlModifier(
+    oid: OID,
+    name: String,
+    summary: String,
+    details: String
+  ) extends InternalMethod(
+      oid,
+      toProps(
+        setName(name),
+        Categories(UITag),
+        Summary(summary),
+        Details(details)
+      )
+    ) {
+
     // Actual Modifier classes should implement this, which does the heart of the work
-    def doTransform(elems:JElems, paramText:String, context:QLContext, params:Seq[QLParam]):Future[JElems]
-    
-    override def qlApply(inv:Invocation):QFut = {
+    def doTransform(
+      elems: JElems,
+      paramText: String,
+      context: QLContext,
+      params: Seq[QLParam]
+    ): Future[JElems]
+
+    override def qlApply(inv: Invocation): QFut = {
       val context = inv.context
       val paramsOpt = inv.paramsOpt
-      
+
       if (paramsOpt.isEmpty)
         throw new PublicException("UI.transform.classRequired", name)
       val params = paramsOpt.get
@@ -156,151 +191,185 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
         // We allow empty values to pass quietly through:
         fut(EmptyValue(QL.ParsedTextType))
       } else {
-        def contentToUse:InvocationValue[DisplayText] = {
+        def contentToUse: InvocationValue[DisplayText] = {
           v.pType match {
-            case RawHtmlType => 
+            case RawHtmlType =>
               for {
                 wikitext <- inv.contextAllAs(RawHtmlType)
-              }
-                yield wikitext.display
+              } yield wikitext.display
             case ParsedTextType =>
               for {
                 wikitext <- inv.contextAllAs(ParsedTextType)
-              }
-                yield wikitext.span
+              } yield wikitext.span
             case _ => {
               val wikitext = context.value.wikify(context).map(_.raw)
               inv.fut(wikitext)
             }
           }
         }
-        
+
         for {
           parsedParam <- inv.processParamFirstAs(0, ParsedTextType)
           paramText = parsedParam.raw.toString
-          content <- contentToUse          
+          content <- contentToUse
           doc = jsoup.Jsoup.parse(content.str)
-                  .outputSettings((new jsoup.nodes.Document.OutputSettings).escapeMode(jsoup.nodes.Entities.EscapeMode.xhtml))
+            .outputSettings((new jsoup.nodes.Document.OutputSettings).escapeMode(jsoup.nodes.Entities.EscapeMode.xhtml))
           realDoc =
             if (doc.body.children.isEmpty)
               // There are no child nodes, which implies that this is just top-level text. In that case, wrap
               // it in a span, so we have something to manipulate:
               jsoup.Jsoup.parse(s"<span>${content.str}</span>")
-                  .outputSettings((new jsoup.nodes.Document.OutputSettings).escapeMode(jsoup.nodes.Entities.EscapeMode.xhtml))
+                .outputSettings(
+                  (new jsoup.nodes.Document.OutputSettings).escapeMode(jsoup.nodes.Entities.EscapeMode.xhtml)
+                )
             else
               doc
           elems <- inv.fut(doTransform(realDoc.body.children, paramText, context, params))
           newHtml = QHtml(elems.toString)
-        }
-          yield QL.WikitextValue(HtmlWikitext(newHtml))
+        } yield QL.WikitextValue(HtmlWikitext(newHtml))
       }
     }
   }
-  
-  lazy val classMethod = new HtmlModifier(ClassMethodOID, "_class",
-      "Add a class tag to the received HTML value",
-      """Usually, to add HTML classes to something (to make them look pretty via CSS), you use the
-            |\{\{class:...\}\} mechanism. But that *wraps* the text, inside of a div or span, and while that is
-            |usually good enough, sometimes it doesn't do everything you need. So _class provides an alternate way
-            |to do this via QL -- given an HTML block, this adds the class to *that* block, instead of wrapping it
-            |in another.
-            |
-            |This is mainly intended for use with _edit, to do something like this:
-            |[[_code(""[[My Thing -> My Prop._edit -> _class(""myClass"")]]"")]]
-            |This will create an Edit input for My Prop, with myClass attached so you can control its display.
-            |
-            |This can also be used to add a class to a given text block:
-            |[[_code(""[[""Hello world"" -> _class(""myClass"")]]"")]]
-            |This will create a paragraph for "hello world" as usual, but will attach "myClass" as a class on that
-            |paragraph. (This is less often necessary, but occasionally helpful.)
-            |
-            |If _class receives a value other than text or HTML, it will render that value, and then apply the
-            |class to it. Therefore, this should usually be at the *end* of your phrase.""".stripMargin)
-  {
-    def doTransform(elems:JElems, paramText:String, context:QLContext, params:Seq[QLParam]):Future[JElems] = 
+
+  lazy val classMethod = new HtmlModifier(
+    ClassMethodOID,
+    "_class",
+    "Add a class tag to the received HTML value",
+    """Usually, to add HTML classes to something (to make them look pretty via CSS), you use the
+      |\{\{class:...\}\} mechanism. But that *wraps* the text, inside of a div or span, and while that is
+      |usually good enough, sometimes it doesn't do everything you need. So _class provides an alternate way
+      |to do this via QL -- given an HTML block, this adds the class to *that* block, instead of wrapping it
+      |in another.
+      |
+      |This is mainly intended for use with _edit, to do something like this:
+      |[[_code(""[[My Thing -> My Prop._edit -> _class(""myClass"")]]"")]]
+      |This will create an Edit input for My Prop, with myClass attached so you can control its display.
+      |
+      |This can also be used to add a class to a given text block:
+      |[[_code(""[[""Hello world"" -> _class(""myClass"")]]"")]]
+      |This will create a paragraph for "hello world" as usual, but will attach "myClass" as a class on that
+      |paragraph. (This is less often necessary, but occasionally helpful.)
+      |
+      |If _class receives a value other than text or HTML, it will render that value, and then apply the
+      |class to it. Therefore, this should usually be at the *end* of your phrase.""".stripMargin
+  ) {
+
+    def doTransform(
+      elems: JElems,
+      paramText: String,
+      context: QLContext,
+      params: Seq[QLParam]
+    ): Future[JElems] =
       fut(elems.addClass(paramText))
 //      Future.successful(HtmlRenderer.addClasses(nodes, paramText))
   }
-  
-  lazy val tooltipMethod = new HtmlModifier(TooltipMethodOID, "_tooltip",
-      "Add a tooltip to the received HTML value",
-      """When you have a title, or some other short text like that, you sometimes want a "tooltip" -- a little
+
+  lazy val tooltipMethod = new HtmlModifier(
+    TooltipMethodOID,
+    "_tooltip",
+    "Add a tooltip to the received HTML value",
+    """When you have a title, or some other short text like that, you sometimes want a "tooltip" -- a little
       |pop-up -- with a better description of what it means. This function lets you add that.
       |
       |Since _tooltip is a function, you have to use it inside a QL expression, like this:
       |[[_code(""[[""My Thing"" -> _tooltip(""My Thing is a special sort of Thing"")]]"")]]
       |In the long run, you will be able to describe a tooltip without using a QL expression, but
-      |for now, this is the way to do it.""".stripMargin)
-  {
-    def doTransform(elems:JElems, paramText:String, context:QLContext, params:Seq[QLParam]):Future[JElems] = {
+      |for now, this is the way to do it.""".stripMargin
+  ) {
+
+    def doTransform(
+      elems: JElems,
+      paramText: String,
+      context: QLContext,
+      params: Seq[QLParam]
+    ): Future[JElems] = {
       val withClass = elems.addClass("_withTooltip")
       fut(elems.attr("title", paramText))
-//      val withClass = HtmlRenderer.addClasses(nodes, "_withTooltip")      
+//      val withClass = HtmlRenderer.addClasses(nodes, "_withTooltip")
 //      Future.successful(XmlHelpers.mapElems(withClass)(_ % Attribute("title", Text(paramText), Null)))
     }
   }
-  
-  lazy val dataMethod = new HtmlModifier(DataMethodOID, "_data",
-      "Add HTML5 data to the received HTML value",
-      """This is mainly for internal use for now. Similarly to the _class function, this lets
+
+  lazy val dataMethod = new HtmlModifier(
+    DataMethodOID,
+    "_data",
+    "Add HTML5 data to the received HTML value",
+    """This is mainly for internal use for now. Similarly to the _class function, this lets
       |you add a data tag to a block. So for example, this:
       |[[_code(""[[""Hello world"" -> _data(""foo"", ""something"")]]"")]]
-      |will add a "data-foo" attribute to the block containing Hello world.""".stripMargin)
-  {
-    def doTransform(elems:JElems, paramText:String, context:QLContext, params:Seq[QLParam]):Future[JElems] = {
+      |will add a "data-foo" attribute to the block containing Hello world.""".stripMargin
+  ) {
+
+    def doTransform(
+      elems: JElems,
+      paramText: String,
+      context: QLContext,
+      params: Seq[QLParam]
+    ): Future[JElems] = {
       if (params.length < 2)
         throw new PublicException("UI.transform.dataRequired")
-      
+
       for {
         processed <- context.parser.get.processExp(params(1).exp, context)
-        dataBlock = processed.value.firstTyped(ParsedTextType).getOrElse(throw new PublicException("UI.transform.dataRequired")).raw
-      }
-        yield elems.attr(s"data-$paramText", dataBlock) 
-        //XmlHelpers.mapElems(nodes)(_ % Attribute(s"data-$paramText", Text(dataBlock), Null))
+        dataBlock = processed.value.firstTyped(ParsedTextType).getOrElse(throw new PublicException(
+          "UI.transform.dataRequired"
+        )).raw
+      } yield elems.attr(s"data-$paramText", dataBlock)
+      //XmlHelpers.mapElems(nodes)(_ % Attribute(s"data-$paramText", Text(dataBlock), Null))
     }
   }
-  
-  lazy val PageHeaderProperty = new SystemProperty(PageHeaderPropOID, LargeTextType, Optional,
+
+  lazy val PageHeaderProperty = new SystemProperty(
+    PageHeaderPropOID,
+    LargeTextType,
+    Optional,
     toProps(
       setName("Page Header"),
       SkillLevel(SkillLevelAdvanced),
       Categories(UITag),
       Summary("Allows you to define the top of the page when looking at this Thing"),
       Details("""Normally, Querki displays each Thing with a fairly complex predefined header,
-          |which includes its Name, Space, Model, edit buttons and so on. This works well
-          |for most cases, but if you want more control over the look and feel of your display, you
-          |can override that by setting this Property.""".stripMargin)))
+                |which includes its Name, Space, Model, edit buttons and so on. This works well
+                |for most cases, but if you want more control over the look and feel of your display, you
+                |can override that by setting this Property.""".stripMargin)
+    )
+  )
 
-  /***********************************************
+  /**
+   * *********************************************
    * FUNCTIONS
-   ***********************************************/
+   * *********************************************
+   */
 
-  class SectionMethod extends InternalMethod(SectionMethodOID,
-    toProps(
-      setName("_section"),
-      Categories(UITag),
-      Summary("Display a List as a Header, followed by its contents"),
-      Details("""_section is intended for the common case where you want to display a section
-          |on the page if and only if a specific List is non-empty. It looks like this:
-          |    My List -> _section(HEADER, DETAILS, EMPTY)
-          |Each of the parameters can be any QL phrase, although they are often just text blocks. They are
-          |treated as follows:
-          |
-          |* HEADER is shown first, if the incoming List is non-empty. It gets the entire List as its Context.
-          |* DETAILS is shown after the header, also getting the incoming List as its Context.
-          |* EMPTY is shown if and only if the List is empty. This lets you show something else if appropriate.
-          |It is optional -- you can leave it off.
-          |
-          |Note that the generated QText will have the HEADER on a separate line from the DETAILS. This is
-          |usually what you want. It means that, for example, if you start the HEADER with "###", it will show
-          |up as a true header, separate from the DETAILS, but if it is just something like "Contents:", the
-          |HEADER and DETAILS will run together, since QText joins ordinary text lines together.""".stripMargin)
-    )) 
-  {
-    override def qlApply(inv:Invocation):QFut = {
+  class SectionMethod
+    extends InternalMethod(
+      SectionMethodOID,
+      toProps(
+        setName("_section"),
+        Categories(UITag),
+        Summary("Display a List as a Header, followed by its contents"),
+        Details("""_section is intended for the common case where you want to display a section
+                  |on the page if and only if a specific List is non-empty. It looks like this:
+                  |    My List -> _section(HEADER, DETAILS, EMPTY)
+                  |Each of the parameters can be any QL phrase, although they are often just text blocks. They are
+                  |treated as follows:
+                  |
+                  |* HEADER is shown first, if the incoming List is non-empty. It gets the entire List as its Context.
+                  |* DETAILS is shown after the header, also getting the incoming List as its Context.
+                  |* EMPTY is shown if and only if the List is empty. This lets you show something else if appropriate.
+                  |It is optional -- you can leave it off.
+                  |
+                  |Note that the generated QText will have the HEADER on a separate line from the DETAILS. This is
+                  |usually what you want. It means that, for example, if you start the HEADER with "###", it will show
+                  |up as a true header, separate from the DETAILS, but if it is just something like "Contents:", the
+                  |HEADER and DETAILS will run together, since QText joins ordinary text lines together.""".stripMargin)
+      )
+    ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       val context = inv.context
       val paramsOpt = inv.paramsOpt
-    
+
       paramsOpt match {
         case Some(params) if (params.length > 0) => {
           val header = params(0).exp
@@ -312,50 +381,63 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
       }
     }
 
-    def buildSection(context:QLContext, header:QLExp, detailsOpt:Option[QLExp], emptyOpt:Option[QLExp]):QFut = {
+    def buildSection(
+      context: QLContext,
+      header: QLExp,
+      detailsOpt: Option[QLExp],
+      emptyOpt: Option[QLExp]
+    ): QFut = {
       val parser = context.parser.get
-      val wikitextFut = if (context.isEmpty) {
-        emptyOpt match {
-          case Some(empty) => parser.contextsToWikitext(parser.processExpAll(empty, context.root))
-          case _ => fut(Wikitext(""))
+      val processor = parser.processor
+      val wikitextFut =
+        if (context.isEmpty) {
+          emptyOpt match {
+            case Some(empty) => parser.processor.contextsToWikitext(processor.processExpAll(empty, context.root))
+            case _           => fut(Wikitext(""))
+          }
+        } else {
+          for {
+            processedHeader <- processor.contextsToWikitext(processor.processExpAll(header, context.forceAsCollection))
+            processedDetails = detailsOpt.map(details => processor.processExpAll(details, context))
+            detailContents <-
+              processedDetails.map(processor.contextsToWikitext(_, true)).getOrElse(Future.successful(Wikitext("")))
+          } yield processedHeader + detailContents
         }
-      } else {
-        for {
-          processedHeader <- parser.contextsToWikitext(parser.processExpAll(header, context.forceAsCollection))
-          processedDetails = detailsOpt.map(details => parser.processExpAll(details, context))
-          detailContents <- processedDetails.map(parser.contextsToWikitext(_, true)).getOrElse(Future.successful(Wikitext("")))
-        }
-          yield processedHeader + detailContents
-      }
       wikitextFut.map(wikitext => QL.WikitextValue(wikitext))
     }
   }
 
-  abstract class ButtonBase(tid:OID, pf:PropMap) extends InternalMethod(tid, pf)
-  {
-    def generateButton(url:String, params:Seq[Wikitext]):scala.xml.Elem
-    
-    def numParams:Int
-    
-    override def qlApply(inv:Invocation):QFut = {
+  abstract class ButtonBase(
+    tid: OID,
+    pf: PropMap
+  ) extends InternalMethod(tid, pf) {
+
+    def generateButton(
+      url: String,
+      params: Seq[Wikitext]
+    ): scala.xml.Elem
+
+    def numParams: Int
+
+    override def qlApply(inv: Invocation): QFut = {
       val context = inv.context
       val paramsOpt = inv.paramsOpt
-      
+
       paramsOpt match {
         case Some(params) if (params.length == numParams) => {
           val urlOpt = context.value.pType match {
-            case pt:URLableType => context.value.firstOpt.flatMap(pt.getURL(context)(_))
-            case _ => None
+            case pt: URLableType => context.value.firstOpt.flatMap(pt.getURL(context)(_))
+            case _               => None
           }
-          
+
           urlOpt match {
             case Some(url) => {
               Future.sequence(
-                params.map(param => 
-                  context.parser.get.processExp(param.exp, context).flatMap(_.value.wikify(context))))
-              .map { paramTexts =>
-                HtmlValue(QHtml(generateButton(url, paramTexts).toString))
-              }
+                params.map(param => context.parser.get.processExp(param.exp, context).flatMap(_.value.wikify(context)))
+              )
+                .map { paramTexts =>
+                  HtmlValue(QHtml(generateButton(url, paramTexts).toString))
+                }
             }
             // Nothing incoming, so cut.
             // TODO: there is probably a general pattern to pull out here, of "cut processing if the input is empty"
@@ -371,26 +453,34 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
    * TODO: add parameters to specify the common style decisions: size (btn-sm, btn-xs, etc) and color (btn-default,
    * btn-warning, btn-danger, etc). These should each take a well-defined enumeration.
    */
-  class LinkButtonBase(oid: OID, name: String, kind: String, isButton: Boolean) extends InternalMethod(oid,
-    toProps(
-      setName(name),
-      Categories(UITag),
-      Summary(s"Displays a $kind that goes to a linked page when you press it."),
-      Signature(
-        expected = Some((Seq(LinkType, ExternalLinkType), s"The Thing or page to go to when this $kind is pressed")),
-        reqs = Seq.empty,
-        opts = Seq(
-          ("label", ParsedTextType, Core.QNone, s"The text to display on this $kind, if any"),
-          ("icon", ParsedTextType, Core.QNone, s"The icon to display on this $kind, if any"),
-          ("tooltip", ParsedTextType, Core.QNone, s"The tooltip to show when the user hovers over this $kind"),
-          ("id", ParsedTextType, Core.QNone, s"The HTML id to give to this $kind")
+  class LinkButtonBase(
+    oid: OID,
+    name: String,
+    kind: String,
+    isButton: Boolean
+  ) extends InternalMethod(
+      oid,
+      toProps(
+        setName(name),
+        Categories(UITag),
+        Summary(s"Displays a $kind that goes to a linked page when you press it."),
+        Signature(
+          expected = Some((Seq(LinkType, ExternalLinkType), s"The Thing or page to go to when this $kind is pressed")),
+          reqs = Seq.empty,
+          opts = Seq(
+            ("label", ParsedTextType, Core.QNone, s"The text to display on this $kind, if any"),
+            ("icon", ParsedTextType, Core.QNone, s"The icon to display on this $kind, if any"),
+            ("tooltip", ParsedTextType, Core.QNone, s"The tooltip to show when the user hovers over this $kind"),
+            ("id", ParsedTextType, Core.QNone, s"The HTML id to give to this $kind")
+          ),
+          returns = (RawHtmlType, s"The $kind as requested")
         ),
-        returns = (RawHtmlType, s"The $kind as requested")
-      ),
-      Details(s"""$name receives a Link or External Link, and displays that
-          |link as a $kind. You should always provide at least a label or an icon.""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+        Details(s"""$name receives a Link or External Link, and displays that
+                   |link as a $kind. You should always provide at least a label or an icon.""".stripMargin)
+      )
+    ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       for {
         pt <- inv.contextTypeAs[URLableType]
         elemContext <- inv.contextElements
@@ -399,29 +489,28 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
         iconOpt <- inv.processAsOpt("icon", ParsedTextType, elemContext)
         tooltipOpt <- inv.processAsOpt("tooltip", ParsedTextType, elemContext)
         idOpt <- inv.processAsOpt("id", ParsedTextType, elemContext)
-        openNewWindow = 
+        openNewWindow =
           (url.startsWith("http:") ||
-           url.startsWith("https:") ||
-           url.startsWith("mailto:"))
-      }
-        yield {
-          HtmlValue(
-            a(
-              if (isButton)
-                cls:="btn btn-primary",
-              href:=url,
-              idOpt.map { idStr => idAttr:=idStr.raw.toString },
-              tooltipOpt.map { tooltip => title:=tooltip.raw.toString },
-              iconOpt.map { icon => iAttr(cls:=s"glyphicon glyphicon-${icon.raw.toString}") },
-              if (openNewWindow)
-                target := "_blank",
-              if (iconOpt.isDefined && labelOpt.isDefined)
-                // Need a space between them:
-                " ",
-              labelOpt.map { label => label.displayWith(new LiteralTransformWrapper(false)).toString }
-            )
+            url.startsWith("https:") ||
+            url.startsWith("mailto:"))
+      } yield {
+        HtmlValue(
+          a(
+            if (isButton)
+              cls := "btn btn-primary",
+            href := url,
+            idOpt.map { idStr => idAttr := idStr.raw.toString },
+            tooltipOpt.map { tooltip => title := tooltip.raw.toString },
+            iconOpt.map { icon => iAttr(cls := s"glyphicon glyphicon-${icon.raw.toString}") },
+            if (openNewWindow)
+              target := "_blank",
+            if (iconOpt.isDefined && labelOpt.isDefined)
+              // Need a space between them:
+              " ",
+            labelOpt.map { label => label.displayWith(new LiteralTransformWrapper(false)).toString }
           )
-        }
+        )
+      }
     }
   }
 
@@ -431,52 +520,68 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
    */
   class LinkButtonMethod extends LinkButtonBase(LinkButtonOID, "_linkButton", "button", true)
   class ShowLinkMethod extends LinkButtonBase(ShowLinkMethodOID, "_showLink", "link", false)
-  
-  class IconButtonMethod extends ButtonBase(IconButtonOID,
-    toProps(
-      setName("_iconButton"),
-      Basic.DeprecatedProp(true),
-      Summary("Displays a button showing an icon, that goes to a linked page when you press it."),
-      Details("""    LINK -> _iconButton(ICON, TOOLTIP)
-          |**DEPRECATED:** use _linkButton instead.
-          |
-          |_iconButton receives a Link or External Link, and displays that
-          |link as a button. The first parameter identifies the icon to use for the button; the second is the
-          |hover text to display as a tooltip. Both parameters are required.
-          |
-          |For icons, you may use anything from the [Bootstrap Glyphicon](http://getbootstrap.com/2.3.2/base-css.html#icons) set.
-          |Just use the name of the icon (in double-double quotes) in the parameter.""".stripMargin)))
-  {
+
+  class IconButtonMethod
+    extends ButtonBase(
+      IconButtonOID,
+      toProps(
+        setName("_iconButton"),
+        Basic.DeprecatedProp(true),
+        Summary("Displays a button showing an icon, that goes to a linked page when you press it."),
+        Details("""    LINK -> _iconButton(ICON, TOOLTIP)
+                  |**DEPRECATED:** use _linkButton instead.
+                  |
+                  |_iconButton receives a Link or External Link, and displays that
+                  |link as a button. The first parameter identifies the icon to use for the button; the second is the
+                  |hover text to display as a tooltip. Both parameters are required.
+                  |
+                  |For icons, you may use anything from the [Bootstrap Glyphicon](http://getbootstrap.com/2.3.2/base-css.html#icons) set.
+                  |Just use the name of the icon (in double-double quotes) in the parameter.""".stripMargin)
+      )
+    ) {
     val numParams = 2
-    
-    def generateButton(url:String, params:Seq[Wikitext]):scala.xml.Elem = {
-      <a class="btn btn-default btn-xs btn-default" href={url} title={params(1).raw}><i class={"glyphicon glyphicon-" + params(0).raw}></i></a>
+
+    def generateButton(
+      url: String,
+      params: Seq[Wikitext]
+    ): scala.xml.Elem = {
+      <a class="btn btn-default btn-xs btn-default" href={url} title={params(1).raw}><i class={
+        "glyphicon glyphicon-" + params(0).raw
+      }></i></a>
     }
   }
-  
-  class MixedButtonMethod extends ButtonBase(MixedButtonOID,
-    toProps(
-      setName("_mixedButton"),
-      Basic.DeprecatedProp(true),
-      Summary("Displays a button showing an icon and a text label, that goes to a linked page when you press it."),
-      Details("""    LINK -> _mixedButton(ICON, LABEL)
-          |**DEPRECATED:** use _linkButton instead.
-          |
-          |_mixedButton receives a Link or External Link, and displays that
-          |link as a button. The first parameter identifies the icon to use for the button; the second is the
-          |text that follows the icon. Both parameters are required. This is essentially a combo of _iconButton
-          |and _linkButton.
-          |
-          |For icons, you may use anything from the [Bootstrap Glyphicon](http://getbootstrap.com/2.3.2/base-css.html#icons) set.
-          |Just use the name of the icon (in double-double quotes) in the parameter.""".stripMargin)))
-  {
+
+  class MixedButtonMethod
+    extends ButtonBase(
+      MixedButtonOID,
+      toProps(
+        setName("_mixedButton"),
+        Basic.DeprecatedProp(true),
+        Summary("Displays a button showing an icon and a text label, that goes to a linked page when you press it."),
+        Details("""    LINK -> _mixedButton(ICON, LABEL)
+                  |**DEPRECATED:** use _linkButton instead.
+                  |
+                  |_mixedButton receives a Link or External Link, and displays that
+                  |link as a button. The first parameter identifies the icon to use for the button; the second is the
+                  |text that follows the icon. Both parameters are required. This is essentially a combo of _iconButton
+                  |and _linkButton.
+                  |
+                  |For icons, you may use anything from the [Bootstrap Glyphicon](http://getbootstrap.com/2.3.2/base-css.html#icons) set.
+                  |Just use the name of the icon (in double-double quotes) in the parameter.""".stripMargin)
+      )
+    ) {
     val numParams = 2
-    
-    def generateButton(url:String, params:Seq[Wikitext]):scala.xml.Elem = {
-      <a class="btn btn-default btn-sm btn-primary" href={url}><i class={"glyphicon glyphicon-" + params(0).raw}></i> {params(1).raw}</a>
+
+    def generateButton(
+      url: String,
+      params: Seq[Wikitext]
+    ): scala.xml.Elem = {
+      <a class="btn btn-default btn-sm btn-primary" href={url}><i class={"glyphicon glyphicon-" + params(0).raw}></i> {
+        params(1).raw
+      }</a>
     }
   }
-  
+
 //  // TODO: this is very similar to _linkButton, and should be refactored.
 //  class ShowLinkMethod extends InternalMethod(ShowLinkMethodOID,
 //    toProps(
@@ -503,92 +608,98 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
 //        yield QValue.make(ExactlyOne, ParsedTextType, wikitext)
 //    }
 //  }
-    
-  class PropLinkMethod extends InternalMethod(PropLinkMethodOID, 
-    toProps(
-      setName("_propLink"),
-      Categories(UITag),
-      Summary("""Produces a Link to a specific Property on a Thing."""),
-      Details("""    THING -> PROPERTY._propLink -> EXTERNAL LINK
-          |A common pattern in Querki is to provide alternate "views" for a Thing -- different ways of displaying it.
-          |Typically, you do this by creating another Large Text Property (separate from Default View), which contains
-          |the alternate view, and then linking to that somewhere. This method makes it easy to do so: feed the THING
-          |and PROPERTY into _propLink, and the result is an EXTERNAL LINK which you can then pass to _showLink,
-          |_linkButton or _iconButton.
-          |
-          |NOTE: this currently only works for Things in the local Space, and probably does *not* work correctly in
-          |sub-Spaces yet.
-          |
-          |This will work for any Property Type, even Types that don't really make sense as Views, so use with a bit
-          |of care!""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
-      for (
-        thing <- inv.contextAllThings;
-        prop <- inv.definingContextAsProperty
+
+  class PropLinkMethod
+    extends InternalMethod(
+      PropLinkMethodOID,
+      toProps(
+        setName("_propLink"),
+        Categories(UITag),
+        Summary("""Produces a Link to a specific Property on a Thing."""),
+        Details(
+          """    THING -> PROPERTY._propLink -> EXTERNAL LINK
+            |A common pattern in Querki is to provide alternate "views" for a Thing -- different ways of displaying it.
+            |Typically, you do this by creating another Large Text Property (separate from Default View), which contains
+            |the alternate view, and then linking to that somewhere. This method makes it easy to do so: feed the THING
+            |and PROPERTY into _propLink, and the result is an EXTERNAL LINK which you can then pass to _showLink,
+            |_linkButton or _iconButton.
+            |
+            |NOTE: this currently only works for Things in the local Space, and probably does *not* work correctly in
+            |sub-Spaces yet.
+            |
+            |This will work for any Property Type, even Types that don't really make sense as Views, so use with a bit
+            |of care!""".stripMargin
+        )
       )
-        yield ExactlyOne(ExternalLinkType(thing.toThingId + "?prop=" + prop.toThingId))
+    ) {
+
+    override def qlApply(inv: Invocation): QFut = {
+      for {
+        thing <- inv.contextAllThings
+        prop <- inv.definingContextAsProperty
+      } yield ExactlyOne(ExternalLinkType(thing.toThingId + "?prop=" + prop.toThingId))
     }
   }
-  
-  def getCreateInstanceUrl(inv:Invocation):InvocationValue[String] = {
+
+  def getCreateInstanceUrl(inv: Invocation): InvocationValue[String] = {
     implicit val state = inv.state
-      // First, figure out the linkback if there is one:
-      val linkParamFut:Future[String] = inv.definingContext match {
-        case Some(definingContext) => {
-          val invStr = for {
-            lexicalThing <- inv.opt(inv.lexicalThing match { case Some(t:Thing) => Some(t); case _ => None})
-            linkProp <- inv.definingContextAsProperty
-            fieldId = new FieldIds(None, linkProp)
-            backLink <- inv.opt(linkProp.pType match {
-              case pt:querki.core.IsLinkType => Some(lexicalThing.id.toThingId.toString)
-              case NewTagSetType => lexicalThing.linkName
-              case _ => None
-            })
-            backLinkSafe = SafeUrl(backLink)
-          }
-            yield s"&${fieldId.inputControlId}=$backLinkSafe"
-            
-          invStr.get.map(_.headOption.getOrElse(""))
-        }
-        case _ => Future.successful("")
+    // First, figure out the linkback if there is one:
+    val linkParamFut: Future[String] = inv.definingContext match {
+      case Some(definingContext) => {
+        val invStr = for {
+          lexicalThing <- inv.opt(inv.lexicalThing match { case Some(t: Thing) => Some(t); case _ => None })
+          linkProp <- inv.definingContextAsProperty
+          fieldId = new FieldIds(None, linkProp)
+          backLink <- inv.opt(linkProp.pType match {
+            case pt: querki.core.IsLinkType => Some(lexicalThing.id.toThingId.toString)
+            case NewTagSetType              => lexicalThing.linkName
+            case _                          => None
+          })
+          backLinkSafe = SafeUrl(backLink)
+        } yield s"&${fieldId.inputControlId}=$backLinkSafe"
+
+        invStr.get.map(_.headOption.getOrElse(""))
       }
-      
-      for {
-        thing <- inv.contextFirstThing
-        url <- inv.fut(linkParamFut.map(PublicUrls.createAndEditUrl(inv.context.request, thing.toThingId) + _))
-      }
-        yield url
+      case _ => Future.successful("")
+    }
+
+    for {
+      thing <- inv.contextFirstThing
+      url <- inv.fut(linkParamFut.map(PublicUrls.createAndEditUrl(inv.context.request, thing.toThingId) + _))
+    } yield url
   }
-  
-  lazy val CreateInstanceLinkMethod = new InternalMethod(CreateInstanceLinkOID,
+
+  lazy val CreateInstanceLinkMethod = new InternalMethod(
+    CreateInstanceLinkOID,
     toProps(
       setName("_createInstanceLink"),
       Categories(UITag),
       Summary("Given a received Model, this produces a Link to create an instance of that Model."),
       Details("""```
-        |MODEL -> _createInstanceLink -> _linkButton(LABEL)
-        |```
-        |This is how you implement a "Create" button. _createInstanceLink takes a MODEL, and produces an External Link to the page to create a new Instance of it.
-        |
-        |You will usually then feed this into, eg, _linkButton or _iconButton as a way to display the Link.
-        |```
-        |MODEL -> LINK PROPERTY._createInstanceLink -> _linkButton(LABEL)
-        |```
-        |
-        |You may optionally specify a Link Property with _createInstanceLink. That means that the newly-created Instance
-        |should point back to *this* Thing -- the one where you have the button -- through the specified Link Property.
-        |This is very useful for creating "child" Thing easily.""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+                |MODEL -> _createInstanceLink -> _linkButton(LABEL)
+                |```
+                |This is how you implement a "Create" button. _createInstanceLink takes a MODEL, and produces an External Link to the page to create a new Instance of it.
+                |
+                |You will usually then feed this into, eg, _linkButton or _iconButton as a way to display the Link.
+                |```
+                |MODEL -> LINK PROPERTY._createInstanceLink -> _linkButton(LABEL)
+                |```
+                |
+                |You may optionally specify a Link Property with _createInstanceLink. That means that the newly-created Instance
+                |should point back to *this* Thing -- the one where you have the button -- through the specified Link Property.
+                |This is very useful for creating "child" Thing easily.""".stripMargin)
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       for {
         url <- getCreateInstanceUrl(inv)
-      }
-        yield ExactlyOne(ExternalLinkType(url))
+      } yield ExactlyOne(ExternalLinkType(url))
     }
   }
-  
-  lazy val CreateButtonFunction = new InternalMethod(CreateButtonOID,
+
+  lazy val CreateButtonFunction = new InternalMethod(
+    CreateButtonOID,
     toProps(
       setName("_createButton"),
       Categories(UITag),
@@ -596,22 +707,33 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
       Signature(
         expected = Some((Seq(LinkType), "The Model to instantiate")),
         reqs = Seq(("label", TextType, "The text to show on the button")),
-        opts = Seq(("classes", TextType, Core.QNone, "Display classes to apply to the button. If not specified, btn-default will be used.")),
+        opts = Seq((
+          "classes",
+          TextType,
+          Core.QNone,
+          "Display classes to apply to the button. If not specified, btn-default will be used."
+        )),
         returns = (RawHtmlType, "The actual button on the page"),
-        defining = Some(false, Seq(LinkType), "A Property -- if given, that Property on the new Instance will point back to here")
+        defining = Some(
+          false,
+          Seq(LinkType),
+          "A Property -- if given, that Property on the new Instance will point back to here"
+        )
       ),
       Details("""This displays a button, with the given **label**, if the user is allowed to create Instances of that Model.
-          |
-          |For example, say we have Models named Bookcase and Book. Book has a My Bookcase property, that points to the case it
-          |is on. I want a button to show on Bookcase that creates a new Book on that case, and I want it to show using the "primary"
-          |style (green). I would add a button to Bookcase, that looks like this:
-          |```
-          |\[[Book -> My Bookcase._createButton(\""Add a Book to this case\"", classes=\""btn-primary\"")\]]
-          |```
-          |Because I give My Bookcase as the Defining Context, Querki uses that property to point from the new Book back
-          |to the Bookcase that created it.""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+                |
+                |For example, say we have Models named Bookcase and Book. Book has a My Bookcase property, that points to the case it
+                |is on. I want a button to show on Bookcase that creates a new Book on that case, and I want it to show using the "primary"
+                |style (green). I would add a button to Bookcase, that looks like this:
+                |```
+                |\[[Book -> My Bookcase._createButton(\""Add a Book to this case\"", classes=\""btn-primary\"")\]]
+                |```
+                |Because I give My Bookcase as the Defining Context, Querki uses that property to point from the new Book back
+                |to the Bookcase that created it.""".stripMargin)
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       for {
         url <- getCreateInstanceUrl(inv)
         labelWikitext <- inv.processAs("label", ParsedTextType)
@@ -619,22 +741,21 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
         classesWikiOpt <- inv.processAsOpt("classes", ParsedTextType)
         allClasses =
           "btn" +
-          classesWikiOpt.map(_.raw.str).map(" " + _).getOrElse(" btn-default")
-      }
-        yield 
-          HtmlValue(
-            a(
-              cls := allClasses,
-              href := url,
-              label
-            )
-          )
+            classesWikiOpt.map(_.raw.str).map(" " + _).getOrElse(" btn-default")
+      } yield HtmlValue(
+        a(
+          cls := allClasses,
+          href := url,
+          label
+        )
+      )
     }
   }
-  
+
   // TODO: replace this with a QL function! It certainly requires basic math functions, but I'm
   // not sure it needs much else...
-  lazy val ShowSomeFunction = new InternalMethod(ShowSomeOID,
+  lazy val ShowSomeFunction = new InternalMethod(
+    ShowSomeOID,
     toProps(
       setName("_showSome"),
       Categories(UITag),
@@ -642,7 +763,7 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
         expected = Some((Seq(AnyType), "A value that will be passed to the parameters.")),
         reqs = Seq(
           ("start", IntType, "The index to begin listing from, usually 0"),
-          ("len", IntType, "The number of entries to show"),          
+          ("len", IntType, "The number of entries to show"),
           ("label", ParsedTextType, "The text to display on the link to show more."),
           ("ql", Basic.QLType, "The QL that lists *all* of the desired entries."),
           ("render", Basic.QLType, "QL describing how to display the entries that will be shown this time.")
@@ -653,21 +774,23 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
       Summary("Show some of the contents at a time"),
       SkillLevel(SkillLevelAdvanced),
       Details("""This is a useful but complex function for dealing with long lists. Given some incoming context,
-        |it runs the expression in `ql` to compute a bunch of expressions. It produces a List of `len` of them
-        |with indexes starting at `start`, feeds that to `render`, and produces the result of that. The whole
-        |thing will be finished with `label`; clicking on that produces the next `len` items.
-        |
-        |The division between `ql` and `render` is a bit subtle, and is mainly for efficiency. `ql` should
-        |contain the code up until the order is clear -- typically until _sort. You *can* put everything
-        |into `ql`, but it will run more slowly, because it will do all the render processing for everything,
-        |including the entries that aren't being shown right now. (That is, when it shows "some", it will
-        |run the `ql`, and then only run `render` on the entries to be displayed.)
-        |
-        |In the long run, this should be replaced by a cleverer and more automatic mechanism. Also, this
-        |may be replaced by a QL function in due course. So consider this experimental; it may go away
-        |down the line.""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+                |it runs the expression in `ql` to compute a bunch of expressions. It produces a List of `len` of them
+                |with indexes starting at `start`, feeds that to `render`, and produces the result of that. The whole
+                |thing will be finished with `label`; clicking on that produces the next `len` items.
+                |
+                |The division between `ql` and `render` is a bit subtle, and is mainly for efficiency. `ql` should
+                |contain the code up until the order is clear -- typically until _sort. You *can* put everything
+                |into `ql`, but it will run more slowly, because it will do all the render processing for everything,
+                |including the entries that aren't being shown right now. (That is, when it shows "some", it will
+                |run the `ql`, and then only run `render` on the entries to be displayed.)
+                |
+                |In the long run, this should be replaced by a cleverer and more automatic mechanism. Also, this
+                |may be replaced by a QL function in due course. So consider this experimental; it may go away
+                |down the line.""".stripMargin)
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       val qv = inv.context.value
       val pt = qv.pType
       for {
@@ -689,7 +812,8 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
             ""
           else {
             val nextDiv = s"_nextButton${(scala.math.random * 1000000).toInt.toString()}"
-            div(idAttr := nextDiv,
+            div(
+              idAttr := nextDiv,
               p(b(a(
                 cls := "_qlInvoke",
                 label.raw.toString,
@@ -697,7 +821,8 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
                 data.ptype := s"${pt.id.toThingId}",
                 data.target := nextDiv,
                 data.noicon := true,
-                data.ql := s"_showSome(${start + len},$len,${rawLabel.reconstructStandalone},${rawQL.reconstructStandalone},${rawDisplay.reconstructStandalone})")))
+                data.ql := s"_showSome(${start + len},$len,${rawLabel.reconstructStandalone},${rawQL.reconstructStandalone},${rawDisplay.reconstructStandalone})"
+              )))
             ).toString
           }
         complete =
@@ -705,16 +830,21 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
             Wikitext("")
           else
             wiki + HtmlWikitext(nextButton)
-      }
-        yield QL.WikitextValue(complete)
+      } yield QL.WikitextValue(complete)
     }
   }
-  
-  abstract class ClickableQLBase(oid:OID, pf:PropMap) extends InternalMethod(oid, pf)
-  {
-    def buildHtml(label:String, core:String):String
-    
-    override def qlApply(inv:Invocation):QFut = {
+
+  abstract class ClickableQLBase(
+    oid: OID,
+    pf: PropMap
+  ) extends InternalMethod(oid, pf) {
+
+    def buildHtml(
+      label: String,
+      core: String
+    ): String
+
+    override def qlApply(inv: Invocation): QFut = {
       val qv = inv.context.value
       // TODO: for the moment, we're using a single context for the label (see below). If that's
       // empty, we synthesize one. This fixed QI.9v5kari, but kind of sucks. Can we do better?
@@ -729,7 +859,7 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
           targetOpt match {
             case Some(target) => (target.raw.str.trim, "")
             case None => {
-              val name = "target-" + scala.util.Random.nextInt.toString 
+              val name = "target-" + scala.util.Random.nextInt.toString
               (name, s"""<div id="$name"></div>""")
             }
           }
@@ -747,22 +877,23 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
         labelWiki <- inv.processAs("label", ParsedTextType, singleContext)
         label = HtmlEscape.escapeQuotes(labelWiki.raw.str.trim)
         lexicalBundleOpt = inv.context.parser.flatMap(_.lexicalThing)
-        lexicalThingOpt = lexicalBundleOpt.flatMap(_ match { case t:Thing => Some(t); case _ => None }) 
+        lexicalThingOpt = lexicalBundleOpt.flatMap(_ match { case t: Thing => Some(t); case _ => None })
         serialized <- QL.serializeContext(inv, Some("ql"))
-      }
-        yield 
-          HtmlValue(
-            buildHtml(
-              label, 
-              s"""data-ptype="${pt.id.toThingId}" data-context=".$serialized" data-target="$targetName" data-ql="$ql" data-append="$append" """ +
-              s"""data-replace="$replace" data-noicon="$noIcon" data-updatesection="$updateSectionAfter" """ +
-              (if (noDiv) """data-nodiv="true" """ else "") +
-              s"""${lexicalThingOpt.map(lex => s"""data-lexical="${lex.id.toThingId}"""").getOrElse("")} href="#" """) 
-            + targetDiv)
+      } yield HtmlValue(
+        buildHtml(
+          label,
+          s"""data-ptype="${pt.id.toThingId}" data-context=".$serialized" data-target="$targetName" data-ql="$ql" data-append="$append" """ +
+            s"""data-replace="$replace" data-noicon="$noIcon" data-updatesection="$updateSectionAfter" """ +
+            (if (noDiv) """data-nodiv="true" """ else "") +
+            s"""${lexicalThingOpt.map(lex => s"""data-lexical="${lex.id.toThingId}"""").getOrElse("")} href="#" """
+        )
+          + targetDiv
+      )
     }
   }
 
-  lazy val QLButton = new ClickableQLBase(QLButtonOID,
+  lazy val QLButton = new ClickableQLBase(
+    QLButtonOID,
     toProps(
       setName("_QLButton"),
       Categories(UITag),
@@ -773,39 +904,75 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
           ("ql", Basic.QLType, "The QL to execute when the button is pressed.")
         ),
         opts = Seq(
-          ("target", ParsedTextType, Core.QNone, """The id of a div or span to put the results into; if it
-                |is not given, the results will be displayed below the button.""".stripMargin),
-          ("append", YesNoType, ExactlyOne(YesNoType(false)), """If set to true, pressing the button again runs
-                |the QL again, and appends the result to the target div. Otherwise, pressing the button again
-                |closes the div.""".stripMargin),
-          ("replace", YesNoType, ExactlyOne(YesNoType(false)), """If set to true, pressing the button again re-runs
-                |the QL, and replaces the value in the target div. (This is rarely useful.)""".stripMargin),
-          ("noIcon", YesNoType, ExactlyOne(YesNoType(false)), """Normally, Querki adds an indicator icon to the button,
-                |showing that it opens and closes. If `noIcon` is set to `True`, that won't be shown.""".stripMargin),
-          ("noDiv", YesNoType, ExactlyOne(YesNoType(false)), """Normally, Querki displays the result of the QL expression
-                |in a div. If `noDiv` is set to `True`, the results will be added with nothing around them.""".stripMargin),
-          ("updateSectionAfter", YesNoType, ExactlyOne(YesNoType(false)), """If this is contained within an `_updateableSection`,
-                |and you set `updateSectionAfter` to `true`, that enclosing section will be redisplayed after this is clicked.""".stripMargin)
+          (
+            "target",
+            ParsedTextType,
+            Core.QNone,
+            """The id of a div or span to put the results into; if it
+              |is not given, the results will be displayed below the button.""".stripMargin
+          ),
+          (
+            "append",
+            YesNoType,
+            ExactlyOne(YesNoType(false)),
+            """If set to true, pressing the button again runs
+              |the QL again, and appends the result to the target div. Otherwise, pressing the button again
+              |closes the div.""".stripMargin
+          ),
+          (
+            "replace",
+            YesNoType,
+            ExactlyOne(YesNoType(false)),
+            """If set to true, pressing the button again re-runs
+              |the QL, and replaces the value in the target div. (This is rarely useful.)""".stripMargin
+          ),
+          (
+            "noIcon",
+            YesNoType,
+            ExactlyOne(YesNoType(false)),
+            """Normally, Querki adds an indicator icon to the button,
+              |showing that it opens and closes. If `noIcon` is set to `True`, that won't be shown.""".stripMargin
+          ),
+          (
+            "noDiv",
+            YesNoType,
+            ExactlyOne(YesNoType(false)),
+            """Normally, Querki displays the result of the QL expression
+              |in a div. If `noDiv` is set to `True`, the results will be added with nothing around them.""".stripMargin
+          ),
+          (
+            "updateSectionAfter",
+            YesNoType,
+            ExactlyOne(YesNoType(false)),
+            """If this is contained within an `_updateableSection`,
+              |and you set `updateSectionAfter` to `true`, that enclosing section will be redisplayed after this is clicked.""".stripMargin
+          )
         ),
         returns = (RawHtmlType, "The button")
       ),
       Summary("Shows a button that, when pressed, executes some QL and can show the result"),
       SkillLevel(SkillLevelAdvanced),
       Details("""This function is unusual, in that it is a way to do something only if the user presses a button.
-          |It displays a button with the given **label**; if the user presses that, it evaluates the given **ql**
-          |(using the received Thing as its context).
-          |
-          |As an example of how to use this, say you have a complex Model Property that you want to make
-          |editable on the Thing's page, but you only want to show it when needed. You can say:
-          |
-          |    \[[_QLButton(\""Edit My Model Property\"", My Model Property._edit)\]]""".stripMargin)))
-  {
-    def buildHtml(label:String, core:String):String = {
+                |It displays a button with the given **label**; if the user presses that, it evaluates the given **ql**
+                |(using the received Thing as its context).
+                |
+                |As an example of how to use this, say you have a complex Model Property that you want to make
+                |editable on the Thing's page, but you only want to show it when needed. You can say:
+                |
+                |    \[[_QLButton(\""Edit My Model Property\"", My Model Property._edit)\]]""".stripMargin)
+    )
+  ) {
+
+    def buildHtml(
+      label: String,
+      core: String
+    ): String = {
       s"""<a class="btn btn-primary _qlInvoke" $core>$label</a>"""
     }
   }
 
-  lazy val QLLink = new ClickableQLBase(QLLinkOID,
+  lazy val QLLink = new ClickableQLBase(
+    QLLinkOID,
     toProps(
       setName("_QLLink"),
       Signature(
@@ -815,19 +982,49 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
           ("ql", Basic.QLType, "The QL to execute when the button is pressed.")
         ),
         opts = Seq(
-          ("target", ParsedTextType, Core.QNone, """The id of a div or span to put the results into; if it
-                |is not given, the results will be displayed below the button.""".stripMargin),
-          ("append", YesNoType, ExactlyOne(YesNoType(false)), """If set to true, clicking the link again runs
-                |the QL again, and appends the result to the target div. Otherwise, clicking the link again
-                |closes the div.""".stripMargin),
-          ("replace", YesNoType, ExactlyOne(YesNoType(false)), """If set to true, clicking the link again re-runs
-                |the QL, and replaces the value in the target div. (This is rarely useful.)""".stripMargin),
-          ("noIcon", YesNoType, ExactlyOne(YesNoType(false)), """Normally, Querki adds an indicator icon to the link,
-                |showing that it opens and closes. If `noIcon` is set to `True`, that won't be shown.""".stripMargin),
-          ("noDiv", YesNoType, ExactlyOne(YesNoType(false)), """Normally, Querki displays the result of the QL expression
-                |in a div. If `noDiv` is set to `True`, the results will be added with nothing around them.""".stripMargin),
-          ("updateSectionAfter", YesNoType, ExactlyOne(YesNoType(false)), """If this is contained within an `_updateableSection`,
-                |and you set `updateSectionAfter` to `true`, that enclosing section will be redisplayed after this is clicked.""".stripMargin)
+          (
+            "target",
+            ParsedTextType,
+            Core.QNone,
+            """The id of a div or span to put the results into; if it
+              |is not given, the results will be displayed below the button.""".stripMargin
+          ),
+          (
+            "append",
+            YesNoType,
+            ExactlyOne(YesNoType(false)),
+            """If set to true, clicking the link again runs
+              |the QL again, and appends the result to the target div. Otherwise, clicking the link again
+              |closes the div.""".stripMargin
+          ),
+          (
+            "replace",
+            YesNoType,
+            ExactlyOne(YesNoType(false)),
+            """If set to true, clicking the link again re-runs
+              |the QL, and replaces the value in the target div. (This is rarely useful.)""".stripMargin
+          ),
+          (
+            "noIcon",
+            YesNoType,
+            ExactlyOne(YesNoType(false)),
+            """Normally, Querki adds an indicator icon to the link,
+              |showing that it opens and closes. If `noIcon` is set to `True`, that won't be shown.""".stripMargin
+          ),
+          (
+            "noDiv",
+            YesNoType,
+            ExactlyOne(YesNoType(false)),
+            """Normally, Querki displays the result of the QL expression
+              |in a div. If `noDiv` is set to `True`, the results will be added with nothing around them.""".stripMargin
+          ),
+          (
+            "updateSectionAfter",
+            YesNoType,
+            ExactlyOne(YesNoType(false)),
+            """If this is contained within an `_updateableSection`,
+              |and you set `updateSectionAfter` to `true`, that enclosing section will be redisplayed after this is clicked.""".stripMargin
+          )
         ),
         returns = (RawHtmlType, "The link, ready for the page")
       ),
@@ -835,20 +1032,26 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
       Summary("Shows a link that, when clicked, executes some QL and can show the result"),
       SkillLevel(SkillLevelAdvanced),
       Details("""This function is unusual, in that it is a way to do something only if the user clicks a link.
-          |It displays a link with the given **label**; if the user clicks that, it evaluates the given **ql**
-          |(using the received Thing as its context).
-          |
-          |As an example of how to use this, say you have a complex Model Property that you want to make
-          |editable on the Thing's page, but you only want to show it when needed. You can say:
-          |
-          |    \[[_QLLink(\""Edit My Model Property\"", My Model Property._edit)\]]""".stripMargin)))
-  {
-    def buildHtml(label:String, core:String):String = {
+                |It displays a link with the given **label**; if the user clicks that, it evaluates the given **ql**
+                |(using the received Thing as its context).
+                |
+                |As an example of how to use this, say you have a complex Model Property that you want to make
+                |editable on the Thing's page, but you only want to show it when needed. You can say:
+                |
+                |    \[[_QLLink(\""Edit My Model Property\"", My Model Property._edit)\]]""".stripMargin)
+    )
+  ) {
+
+    def buildHtml(
+      label: String,
+      core: String
+    ): String = {
       s"""<a class="_qlInvoke" $core>$label</a>"""
     }
   }
 
-  lazy val QLInput = new ClickableQLBase(QLInputOID,
+  lazy val QLInput = new ClickableQLBase(
+    QLInputOID,
     toProps(
       setName("_QLInput"),
       Signature(
@@ -858,36 +1061,71 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
           ("ql", Basic.QLType, "The QL to execute when the user presses Enter.")
         ),
         opts = Seq(
-          ("target", ParsedTextType, Core.QNone, """The id of a div or span to put the results into; if it
-                |is not given, the results will be displayed below the input.""".stripMargin),
-          ("append", YesNoType, ExactlyOne(YesNoType(false)), """If set to true, entering something else runs
-                |the QL again, and appends the result to the target div. Otherwise, pressing Enter again
-                |closes the div.""".stripMargin),
-          ("replace", YesNoType, ExactlyOne(YesNoType(false)), """If set to true, pressing Enter again re-runs
-                |the QL with the new value of the input field, and replaces the previous result in the target div.""".stripMargin),
+          (
+            "target",
+            ParsedTextType,
+            Core.QNone,
+            """The id of a div or span to put the results into; if it
+              |is not given, the results will be displayed below the input.""".stripMargin
+          ),
+          (
+            "append",
+            YesNoType,
+            ExactlyOne(YesNoType(false)),
+            """If set to true, entering something else runs
+              |the QL again, and appends the result to the target div. Otherwise, pressing Enter again
+              |closes the div.""".stripMargin
+          ),
+          (
+            "replace",
+            YesNoType,
+            ExactlyOne(YesNoType(false)),
+            """If set to true, pressing Enter again re-runs
+              |the QL with the new value of the input field, and replaces the previous result in the target div.""".stripMargin
+          ),
           ("noIcon", YesNoType, ExactlyOne(YesNoType(false)), """Not currently used in _QLInput.""".stripMargin),
-          ("noDiv", YesNoType, ExactlyOne(YesNoType(false)), """Normally, Querki displays the result of the QL expression
-                |in a div. If `noDiv` is set to `True`, the results will be added with nothing around them.""".stripMargin),
-          ("updateSectionAfter", YesNoType, ExactlyOne(YesNoType(false)), """If this is contained within an `_updateableSection`,
-                |and you set `updateSectionAfter` to `true`, that enclosing section will be redisplayed after this is clicked.""".stripMargin)
+          (
+            "noDiv",
+            YesNoType,
+            ExactlyOne(YesNoType(false)),
+            """Normally, Querki displays the result of the QL expression
+              |in a div. If `noDiv` is set to `True`, the results will be added with nothing around them.""".stripMargin
+          ),
+          (
+            "updateSectionAfter",
+            YesNoType,
+            ExactlyOne(YesNoType(false)),
+            """If this is contained within an `_updateableSection`,
+              |and you set `updateSectionAfter` to `true`, that enclosing section will be redisplayed after this is clicked.""".stripMargin
+          )
         ),
         returns = (RawHtmlType, "The input field, ready for the page")
       ),
       Categories(UITag),
-      Summary("Shows an input field that, when the user types some text and presses Enter, executes some QL and can show the result"),
+      Summary(
+        "Shows an input field that, when the user types some text and presses Enter, executes some QL and can show the result"
+      ),
       SkillLevel(SkillLevelAdvanced),
-      Details("""This function is unusual, in that it is a way to do something only if the user enters some text.
+      Details(
+        """This function is unusual, in that it is a way to do something only if the user enters some text.
           |It displays an input with the given **placeholder**; if the user clicks that, it evaluates the given **ql**
           |(using the received Thing as its context).
           |
-          |The entered input text is available in the QL expression as $input.""".stripMargin)))
-  {
-    def buildHtml(label:String, core:String):String = {
+          |The entered input text is available in the QL expression as $input.""".stripMargin
+      )
+    )
+  ) {
+
+    def buildHtml(
+      label: String,
+      core: String
+    ): String = {
       s"""<input type="text" class="_qlInvoke" placeholder="$label" $core></input>"""
     }
   }
-  
-  lazy val UpdateableSection = new InternalMethod(UpdateableSectionOID,
+
+  lazy val UpdateableSection = new InternalMethod(
+    UpdateableSectionOID,
     toProps(
       setName("_updateableSection"),
       SkillLevel(SkillLevelAdvanced),
@@ -898,9 +1136,14 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
           ("contents", AnyType, "The contents of this section")
         ),
         opts = Seq.empty,
-        returns = (RawHtmlType, "The rendered section, which can be updated by setting `_updateSectionAfter` on a QLButton, QLLink or QLInput inside it.")
-      )))
-  {
+        returns = (
+          RawHtmlType,
+          "The rendered section, which can be updated by setting `_updateSectionAfter` on a QLButton, QLLink or QLInput inside it."
+        )
+      )
+    )
+  ) {
+
     override def qlApply(inv: Invocation): QFut = {
       val qv = inv.context.value
       for {
@@ -911,25 +1154,24 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
         contents <- inv.process("contents")
         pt = qv.pType
         lexicalBundleOpt = inv.context.parser.flatMap(_.lexicalThing)
-        lexicalThingOpt = lexicalBundleOpt.flatMap(_ match { case t:Thing => Some(t); case _ => None }) 
+        lexicalThingOpt = lexicalBundleOpt.flatMap(_ match { case t: Thing => Some(t); case _ => None })
         contentsWiki <- inv.fut(contents.wikify(inv.context, None, lexicalThingOpt))
         serialized <- QL.serializeContext(inv, Some("contents"))
         targetName = "target-" + scala.util.Random.nextInt.toString
-      }
-        yield 
-          QL.WikitextValue(
-            HtmlWikitext(
-              s"""<updateable id="$targetName" data-ptype="${pt.id.toThingId}" data-context=".$serialized" data-ql="$contentsQuoted"""" +
-              s"""${lexicalThingOpt.map(lex => s"""data-lexical="${lex.id.toThingId}"""").getOrElse("")} href="#" """ +
-              ">"
-            ) +
-            contentsWiki +
-            HtmlWikitext(s"""</updateable>""")
-          )
+      } yield QL.WikitextValue(
+        HtmlWikitext(
+          s"""<updateable id="$targetName" data-ptype="${pt.id.toThingId}" data-context=".$serialized" data-ql="$contentsQuoted"""" +
+            s"""${lexicalThingOpt.map(lex => s"""data-lexical="${lex.id.toThingId}"""").getOrElse("")} href="#" """ +
+            ">"
+        ) +
+          contentsWiki +
+          HtmlWikitext(s"""</updateable>""")
+      )
     }
   }
-  
-  lazy val ThingTree = new InternalMethod(QLTreeOID,
+
+  lazy val ThingTree = new InternalMethod(
+    QLTreeOID,
     toProps(
       setName("_thingTree"),
       SkillLevel(SkillLevelAdvanced),
@@ -938,17 +1180,34 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
         expected = Some((Seq(LinkType), "One or more Things to display as equal nodes in a tree")),
         reqs = Seq(),
         opts = Seq(
-          ("text", TextType, Core.QNone, "The text to display for this node. If omitted, will be shown as a link to this Thing as usual."),
-          ("children", Basic.QLType, Core.QNone, "A QL expression that produces the children of this node, which should be more _QLTrees. If empty, this node is a leaf."),
+          (
+            "text",
+            TextType,
+            Core.QNone,
+            "The text to display for this node. If omitted, will be shown as a link to this Thing as usual."
+          ),
+          (
+            "children",
+            Basic.QLType,
+            Core.QNone,
+            "A QL expression that produces the children of this node, which should be more _QLTrees. If empty, this node is a leaf."
+          ),
           ("id", TextType, Core.QNone, "The jsTree id to use for this node."),
           ("icon", TextType, Core.QNone, "The icon to display for this node. If not specified, no icon will be shown."),
-          ("opened", YesNoType, ExactlyOne(Logic.False), "If set to True, children of this node will be displayed immediately.")
+          (
+            "opened",
+            YesNoType,
+            ExactlyOne(Logic.False),
+            "If set to True, children of this node will be displayed immediately."
+          )
         ),
         returns = (RawHtmlType, "The tree, or a child node under a higher-level tree")
       ),
-      Summary("Display a tree node, which will invoke the specified QL code to get its children")))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+      Summary("Display a tree node, which will invoke the specified QL code to get its children")
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       for {
         (bundle, elem) <- inv.contextBundlesAndContexts
         thing <- inv.opt(bundle.asThing)
@@ -959,23 +1218,22 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
         iconOpt <- inv.processAsOpt("icon", ParsedTextType, elem)
         idOpt <- inv.processAsOpt("id", ParsedTextType, elem)
         opened <- inv.processAs("opened", YesNoType, elem)
-      }
-        yield 
-          HtmlValue(
-            span(
-              cls:="_qlTree",
-              iconOpt.map(icon => data.icon := icon.raw.toString),
-              data.opened := opened,
-              data.thingid := thing.toThingId.toString,
-              idOpt.map(id => data.id := id.raw.toString),
-              raw(text.raw),
-              qlOpt.map(ql => span(cls:="_treeQL", raw(ql), display:="none"))
-            )
-          )
+      } yield HtmlValue(
+        span(
+          cls := "_qlTree",
+          iconOpt.map(icon => data.icon := icon.raw.toString),
+          data.opened := opened,
+          data.thingid := thing.toThingId.toString,
+          idOpt.map(id => data.id := id.raw.toString),
+          raw(text.raw),
+          qlOpt.map(ql => span(cls := "_treeQL", raw(ql), display := "none"))
+        )
+      )
     }
   }
-  
-  lazy val MenuButton = new InternalMethod(MenuButtonOID,
+
+  lazy val MenuButton = new InternalMethod(
+    MenuButtonOID,
     toProps(
       setName("_menuButton"),
       SkillLevel(SkillLevelAdvanced),
@@ -988,69 +1246,81 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
           ("label", TextType, "What to show on the button")
         ),
         opts = Seq(
-          ("class", TextType, Core.QNone, "Additional space-separated Bootstrap classes to use for displaying this button")
+          (
+            "class",
+            TextType,
+            Core.QNone,
+            "Additional space-separated Bootstrap classes to use for displaying this button"
+          )
         ),
         returns = (RawHtmlType, "The button")
       ),
       Details("""Sometimes, you want to be able to create a button that mimics the effect of a menu item. This
-        |function allows you to do that.
-        |
-        |For example, the "Design a New Model" button on the default Space page looks like this:
-        |```
-        |_menuButton(\""designAModel\"", \""Design a New Model\"", class=\""btn-xs btn-primary\"")
-        |```
-        |""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+                |function allows you to do that.
+                |
+                |For example, the "Design a New Model" button on the default Space page looks like this:
+                |```
+                |_menuButton(\""designAModel\"", \""Design a New Model\"", class=\""btn-xs btn-primary\"")
+                |```
+                |""".stripMargin)
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       for {
         id <- inv.processAs("id", ParsedTextType)
         label <- inv.processAs("label", ParsedTextType)
         classesOpt <- inv.processAsOpt("class", ParsedTextType)
         classes = "_menuButton btn" +
           classesOpt.map(_.strip.toString).map(" " + _).getOrElse("")
-      }
-        yield HtmlValue(
-          a(
-            cls:=classes,
-            data.menuid := id.strip.toString(),
-            label.strip.toString()))
+      } yield HtmlValue(
+        a(
+          cls := classes,
+          data.menuid := id.strip.toString(),
+          label.strip.toString()
+        )
+      )
     }
   }
-  
-  lazy val UniqueHtmlId = new InternalMethod(UniqueHtmlIdOID,
+
+  lazy val UniqueHtmlId = new InternalMethod(
+    UniqueHtmlIdOID,
     toProps(
       setName("_uniqueHtmlId"),
       SkillLevel(SkillLevelAdvanced),
       Categories(UITag),
       Summary("Generate an ID suitable for using on tags in this page."),
       Details("""It is fairly common, especially when doing complex things with _QLButton, to find that you want a
-        |distinct ID for the target of the button, separately for each button on the page. If the _QLButton is
-        |being used with a Thing, you can often use `_oid` to create that ID, but otherwise it can be tricky.
-        |
-        |So the `_uniqueHtmlId` function simply generates a random ID string, suitable for use on the page.
-        |
-        |You typically use this something like:
-        |```
-        |My Things -> _foreach(
-        |_uniqueHtmlId -> +$displayId
-        |\""\[[_QLButton(label=..., target=$displayId, ql=...)\]]
-        |...
-        |<div id="$displayId"></div>
-        |\""
-        |)
-        |```
-        |
-        |*Note*: at the moment, these IDs are generated randomly, so they are not absolutely guaranteed to be
-        |unique -- there is a very small, but non-zero, chance of an ID collision on the page.""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+                |distinct ID for the target of the button, separately for each button on the page. If the _QLButton is
+                |being used with a Thing, you can often use `_oid` to create that ID, but otherwise it can be tricky.
+                |
+                |So the `_uniqueHtmlId` function simply generates a random ID string, suitable for use on the page.
+                |
+                |You typically use this something like:
+                |```
+                |My Things -> _foreach(
+                |_uniqueHtmlId -> +$displayId
+                |\""\[[_QLButton(label=..., target=$displayId, ql=...)\]]
+                |...
+                |<div id="$displayId"></div>
+                |\""
+                |)
+                |```
+                |
+                |*Note*: at the moment, these IDs are generated randomly, so they are not absolutely guaranteed to be
+                |unique -- there is a very small, but non-zero, chance of an ID collision on the page.""".stripMargin)
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       // The input is actually irrelevant:
       val n = (scala.math.random * Long.MaxValue).toLong
       fut(QL.WikitextValue(models.Wikitext(s"_rndid${n.toString}")))
     }
   }
 
-  lazy val TextInputMethod = new InternalMethod(TextInputOID,
+  lazy val TextInputMethod = new InternalMethod(
+    TextInputOID,
     toProps(
       setName("_textInput"),
       Categories(UITag),
@@ -1061,7 +1331,12 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
         ),
         opts = Seq(
           ("placeholder", TextType, Core.QNone, "Some placeholder text to display when the field is empty"),
-          ("clearbutton", YesNoType, ExactlyOne(Logic.False), "If set to true, will show a button that clears the text field")
+          (
+            "clearbutton",
+            YesNoType,
+            ExactlyOne(Logic.False),
+            "If set to true, will show a button that clears the text field"
+          )
         )
       ),
       Details(
@@ -1072,33 +1347,33 @@ class UIModule(e:Ecology) extends QuerkiEcot(e) with HtmlUI with querki.core.Met
           |
           |For example, this works with the [[_checkList._self]] function, letting you filter the checklist items
           |being displayed, or add new ones.
-          |""".stripMargin)
-    ))
-  {
+          |""".stripMargin
+      )
+    )
+  ) {
+
     override def qlApply(inv: Invocation) = {
       for {
         idStr <- inv.processAs("id", TextType)
         placeholderTxt <- inv.processAsOpt("placeholder", TextType)
         clearButton <- inv.processAs("clearbutton", YesNoType)
-      }
-        yield HtmlValue(
-          span(
-            cls := "_rxTextInput",
-            data.elemid := idStr.text,
-            data.clearbutton := clearButton,
-            if (placeholderTxt.isDefined)
-              data.placeholder := placeholderTxt.get.text
-          )
+      } yield HtmlValue(
+        span(
+          cls := "_rxTextInput",
+          data.elemid := idStr.text,
+          data.clearbutton := clearButton,
+          if (placeholderTxt.isDefined)
+            data.placeholder := placeholderTxt.get.text
         )
+      )
     }
   }
-  
+
   override lazy val props = Seq(
     classMethod,
     tooltipMethod,
     dataMethod,
     PageHeaderProperty,
-    
     new SectionMethod,
     new LinkButtonMethod,
     new IconButtonMethod,

--- a/querki/scalajvm/app/querki/ql/Invocation.scala
+++ b/querki/scalajvm/app/querki/ql/Invocation.scala
@@ -4,7 +4,7 @@ import scala.reflect.ClassTag
 
 import querki.values.SpaceState
 
-import models.{AsOID, Collection, Property, PropertyBundle, PType, Thing, ThingId}
+import models.{AsOID, Collection, PType, Property, PropertyBundle, Thing, ThingId}
 
 import querki.ecology._
 import querki.globals._
@@ -16,36 +16,44 @@ import querki.values.{QLContext, QValue, SpaceState}
  * Extra information that can get picked up and carried along with the InvocationValue. Pulled out to here,
  * to keep it from clogging up the logic of the main InvocationValueImpl.
  */
-private [ql] case class IVMetadata(
-    // Allows the Function to declare which PType it expects to return. This allows us to preserve type safety
-    // even when we return QNone.
-    returnType:Option[PType[_]] = None,
-    preferredColl:Option[Collection] = None)
-{
+private[ql] case class IVMetadata(
+  // Allows the Function to declare which PType it expects to return. This allows us to preserve type safety
+  // even when we return QNone.
+  returnType: Option[PType[_]] = None,
+  preferredColl: Option[Collection] = None
+) {
+
   /**
    * This method is the heart of IVMetadata, allowing us to combine metadatas in flatMap(). The copy
    * should account for all parameters.
    */
-  def +(other:IVMetadata) = {
+  def +(other: IVMetadata) = {
     this.copy(
-        returnType = this.returnType orElse other.returnType,
-        preferredColl = this.preferredColl orElse other.preferredColl)
+      returnType = this.returnType.orElse(other.returnType),
+      preferredColl = this.preferredColl.orElse(other.preferredColl)
+    )
   }
 }
 
 private[ql] case class IVData[T](
-    vs:Iterable[T],
-    metadata:IVMetadata = IVMetadata()) 
+  vs: Iterable[T],
+  metadata: IVMetadata = IVMetadata()
+)
 
-private[ql] case class InvocationValueImpl[T](inv:Invocation, fut:Future[IVData[T]])(implicit val ecology:Ecology) 
-  extends InvocationValue[T] with EcologyMember
-{ self =>
-  def map[R](f:T => R):InvocationValue[R] = {
+private[ql] case class InvocationValueImpl[T](
+  inv: Invocation,
+  fut: Future[IVData[T]]
+)(implicit
+  val ecology: Ecology
+) extends InvocationValue[T]
+     with EcologyMember { self =>
+
+  def map[R](f: T => R): InvocationValue[R] = {
     val maps = fut.map(data => IVData(data.vs.map(v => f(v)), data.metadata))
     InvocationValueImpl(inv, maps)
   }
-  
-  def flatMap[R](f:T => InvocationValue[R]):InvocationValue[R] = {
+
+  def flatMap[R](f: T => InvocationValue[R]): InvocationValue[R] = {
     val results = fut.flatMap { data =>
       // Check for timeouts. This is decidedly rough and ready, but should generally suffice to shut things down
       // if they get pathological. When the QL pipeline gets rewritten to be properly monadic, we should be able
@@ -56,112 +64,143 @@ private[ql] case class InvocationValueImpl[T](inv:Invocation, fut:Future[IVData[
       } else {
         val subs = data.vs.map(f(_)).map(_.asInstanceOf[InvocationValueImpl[R]])
         val subFuts = subs.map(_.fut)
-        Future.sequence(subFuts) map { subDatas =>
+        Future.sequence(subFuts).map { subDatas =>
           val resultVs = subDatas.map(_.vs).flatten
-          val resultMetas = (data.metadata /: subDatas.map(_.metadata)) (_ + _)
+          val resultMetas = (data.metadata /: subDatas.map(_.metadata))(_ + _)
           IVData(resultVs, resultMetas)
         }
       }
     }
-    
+
     InvocationValueImpl(inv, results)
   }
 
   /**
    * Our implementation of withFilter, for "if" statements in for comprehensions.
    */
-  class WithFilterImpl(f:T => Boolean) extends WithFilter[T] {
-    def map[R](mf:T => R):InvocationValue[R] = 
+  class WithFilterImpl(f: T => Boolean) extends WithFilter[T] {
+
+    def map[R](mf: T => R): InvocationValue[R] =
       new InvocationValueImpl(inv, self.fut.map(data => IVData(data.vs.filter(f), data.metadata))).map(mf)
-    def flatMap[R](mf:T => InvocationValue[R]):InvocationValue[R] = 
+
+    def flatMap[R](mf: T => InvocationValue[R]): InvocationValue[R] =
       new InvocationValueImpl(inv, self.fut.map(data => IVData(data.vs.filter(f), data.metadata))).flatMap(mf)
-    def withFilter(g:T => Boolean):WithFilter[T] = new WithFilterImpl((x => f(x) && g(x)))
+    def withFilter(g: T => Boolean): WithFilter[T] = new WithFilterImpl((x => f(x) && g(x)))
   }
-  def withFilter(f:T => Boolean):WithFilter[T] = new WithFilterImpl(f)
-    
-  def get:Future[Iterable[T]] = fut.map(_.vs)
-  
-  def all:InvocationValue[Iterable[T]] = {
+  def withFilter(f: T => Boolean): WithFilter[T] = new WithFilterImpl(f)
+
+  def get: Future[Iterable[T]] = fut.map(_.vs)
+
+  def all: InvocationValue[Iterable[T]] = {
     val allFut = fut.map { ivd =>
       IVData(List(ivd.vs), ivd.metadata)
     }
     InvocationValueImpl(inv, allFut)
   }
-  
+
   def one: InvocationValue[T] = {
     val oneFut = fut.map { ivd =>
       IVData(ivd.vs.headOption, ivd.metadata)
     }
-    InvocationValueImpl(inv, oneFut)    
+    InvocationValueImpl(inv, oneFut)
   }
 }
 
 object InvocationValueImpl {
-  def apply[T](ex:PublicException)(implicit inv:Invocation, ecology:Ecology):InvocationValueImpl[T] = 
+
+  def apply[T](
+    ex: PublicException
+  )(implicit
+    inv: Invocation,
+    ecology: Ecology
+  ): InvocationValueImpl[T] =
     InvocationValueImpl[T](inv, Future.failed(ex))
-  def apply[T](vs:Iterable[T])(implicit inv:Invocation, ecology:Ecology):InvocationValueImpl[T] = 
+
+  def apply[T](
+    vs: Iterable[T]
+  )(implicit
+    inv: Invocation,
+    ecology: Ecology
+  ): InvocationValueImpl[T] =
     InvocationValueImpl[T](inv, Future.successful(IVData(vs)))
-  def apply(meta:IVMetadata)(implicit inv:Invocation, ecology:Ecology):InvocationValueImpl[Boolean] =
+
+  def apply(
+    meta: IVMetadata
+  )(implicit
+    inv: Invocation,
+    ecology: Ecology
+  ): InvocationValueImpl[Boolean] =
     InvocationValueImpl(inv, Future.successful(IVData(Some(true), meta)))
 }
 
-private[ql] case class InvocationImpl(invokedOn:Thing, method:Thing, 
-    receivedContext:QLContext, val definingContext:Option[QLContext], 
-    paramsOpt:Option[Seq[QLParam]])
-  (implicit val ecology:Ecology) 
-  extends Invocation with EcologyMember
-{
+private[ql] case class InvocationImpl(
+  invokedOn: Thing,
+  method: Thing,
+  receivedContext: QLContext,
+  val definingContext: Option[QLContext],
+  paramsOpt: Option[Seq[QLParam]]
+)(implicit
+  val ecology: Ecology
+) extends Invocation
+     with EcologyMember {
   lazy val Basic = interface[querki.basic.Basic]
   lazy val Core = interface[querki.core.Core]
   lazy val QL = interface[querki.ql.QL]
   lazy val SignatureInternal = interface[SignatureInternal]
   lazy val Tags = interface[querki.tags.Tags]
   lazy val Types = interface[querki.types.Types]
-  
+
   lazy val displayName = invokedOn.displayName
   lazy val ExactlyOne = Core.ExactlyOne
   lazy val LinkType = Core.LinkType
-  
+
   implicit val inv = this
-  
+
   /**
    * The signature for this function, which we use to extract specific params.
    */
   lazy val sig = SignatureInternal.getSignature(method, context.state, paramsOpt)
-  
-  def error[VT](name:String, params:String*) = InvocationValueImpl[VT](PublicException(name, params:_*))
-  
-  def test(predicate: => Boolean, errorName:String, params: => Seq[Any]):InvocationValue[Boolean] = {
+
+  def error[VT](
+    name: String,
+    params: String*
+  ) = InvocationValueImpl[VT](PublicException(name, params: _*))
+
+  def test(
+    predicate: => Boolean,
+    errorName: String,
+    params: => Seq[Any]
+  ): InvocationValue[Boolean] = {
     if (predicate)
       InvocationValueImpl(Some(true))
     else
-      InvocationValueImpl(PublicException(errorName, params:_*))
+      InvocationValueImpl(PublicException(errorName, params: _*))
   }
-  
-  def returnsType(pt:PType[_]):InvocationValue[Boolean] = {
+
+  def returnsType(pt: PType[_]): InvocationValue[Boolean] = {
     InvocationValueImpl(IVMetadata(returnType = Some(pt)))
   }
-  
-  def preferCollection(coll:Collection):InvocationValue[Boolean] = {
+
+  def preferCollection(coll: Collection): InvocationValue[Boolean] = {
     InvocationValueImpl(IVMetadata(preferredColl = Some(coll)))
   }
-  
-  def preferDefiningContext:Invocation = {
+
+  def preferDefiningContext: Invocation = {
     definingContext match {
       case Some(c) => this.copy(receivedContext = c)
-      case None => this.copy(definingContext = Some(receivedContext))
+      case None    => this.copy(definingContext = Some(receivedContext))
     }
   }
-  
-  def contextTypeAs[T : ClassTag]:InvocationValue[T] = {
+
+  def contextTypeAs[T : ClassTag]: InvocationValue[T] = {
     val clazz = implicitly[ClassTag[T]].runtimeClass
     if (clazz.isInstance(context.value.pType))
       InvocationValueImpl(Some(context.value.pType.asInstanceOf[T]))
     else
       error("Func.wrongType", displayName, context.value.pType.displayName)
   }
-  
-  def contextElements:InvocationValue[QLContext] = {
+
+  def contextElements: InvocationValue[QLContext] = {
     if (context.useCollection) {
       InvocationValueImpl(Some(context))
     } else {
@@ -169,20 +208,23 @@ private[ql] case class InvocationImpl(invokedOn:Thing, method:Thing,
       InvocationValueImpl(contexts)
     }
   }
-  
-  def contextValue:InvocationValue[QValue] = {
+
+  def contextValue: InvocationValue[QValue] = {
     InvocationValueImpl(Some(context.value))
   }
-  
-  def wrap[T](v:T):InvocationValue[T] = {
+
+  def wrap[T](v: T): InvocationValue[T] = {
     InvocationValueImpl(Some(v))
   }
-  
-  def fut[T](fut:Future[T]):InvocationValue[T] = {
+
+  def fut[T](fut: Future[T]): InvocationValue[T] = {
     InvocationValueImpl(this, fut.map(t => IVData(Some(t))))
   }
-  
-  def opt[T](opt:Option[T], errOpt:Option[PublicException] = None):InvocationValue[T] = {
+
+  def opt[T](
+    opt: Option[T],
+    errOpt: Option[PublicException] = None
+  ): InvocationValue[T] = {
     opt match {
       case Some(v) => InvocationValueImpl(Some(v))
       case None => {
@@ -195,21 +237,24 @@ private[ql] case class InvocationImpl(invokedOn:Thing, method:Thing,
     }
   }
 
-  def iter[T](it:Iterable[T], errOpt:Option[PublicException] = None):InvocationValue[T] = {
+  def iter[T](
+    it: Iterable[T],
+    errOpt: Option[PublicException] = None
+  ): InvocationValue[T] = {
     errOpt match {
       case Some(ex) => InvocationValueImpl(ex)
-      case None => InvocationValueImpl(it)
+      case None     => InvocationValueImpl(it)
     }
   }
-  
-  def contextFirstAs[VT](pt:PType[VT]):InvocationValue[VT] = {
+
+  def contextFirstAs[VT](pt: PType[VT]): InvocationValue[VT] = {
     context.value.firstAs(pt) match {
       case Some(v) => InvocationValueImpl(Some(v))
-      case None => error("Func.notThing", displayName)
+      case None    => error("Func.notThing", displayName)
     }
   }
-  
-  def contextAllAs[VT](pt:PType[VT]):InvocationValue[VT] = {
+
+  def contextAllAs[VT](pt: PType[VT]): InvocationValue[VT] = {
     if (!context.value.matchesType(pt))
       error("Func.notThing", displayName)
     else {
@@ -217,17 +262,17 @@ private[ql] case class InvocationImpl(invokedOn:Thing, method:Thing,
       InvocationValueImpl(vs)
     }
   }
-  
-  def contextFirstThing:InvocationValue[Thing] = {
+
+  def contextFirstThing: InvocationValue[Thing] = {
     contextFirstAs(Core.LinkType).flatMap { oid =>
       state.anything(oid) match {
         case Some(thing) => InvocationValueImpl(Some(thing))
-        case None => error("Func.unknownThing", displayName)
+        case None        => error("Func.unknownThing", displayName)
       }
     }
   }
-  
-  def contextAllThings(ctx:QLContext = context):InvocationValue[Thing] = {
+
+  def contextAllThings(ctx: QLContext = context): InvocationValue[Thing] = {
     if (ctx.value.matchesType(Core.UnknownType)) {
       InvocationValueImpl(None)
     } else if (!ctx.value.matchesType(Core.LinkType)) {
@@ -239,66 +284,65 @@ private[ql] case class InvocationImpl(invokedOn:Thing, method:Thing,
         InvocationValueImpl(thingsOpt.flatten)
       else
         error("Func.unknownThing", displayName)
-    }    
+    }
   }
-  
-  def contextAllBundles:InvocationValue[PropertyBundle] = {
+
+  def contextAllBundles: InvocationValue[PropertyBundle] = {
     if (context.value.matchesType(Core.LinkType)) {
       val ids = context.value.flatMap(Core.LinkType)(Some(_))
       val thingsOpt = ids.map(state.anything(_))
       if (thingsOpt.forall(_.isDefined))
         InvocationValueImpl(thingsOpt.flatten)
       else
-        error("Func.unknownThing", displayName)      
+        error("Func.unknownThing", displayName)
     } else if (context.value.matchesType(Core.UnknownType)) {
       InvocationValueImpl(None)
     } else context.value.pType match {
-      case mt:ModelTypeBase => {
+      case mt: ModelTypeBase => {
         val bundles = context.value.flatMap(mt)(Some(_))
         InvocationValueImpl(bundles)
       }
       case _ => error("Func.notThing", displayName)
-    } 
+    }
   }
-  
-  def contextBundlesAndContexts:InvocationValue[(PropertyBundle, QLContext)] = {
+
+  def contextBundlesAndContexts: InvocationValue[(PropertyBundle, QLContext)] = {
     if (context.value.matchesType(Core.LinkType)) {
       val ids = context.value.flatMap(Core.LinkType)(Some(_))
       val thingsOpt = ids.map(state.anything(_))
       if (thingsOpt.forall(_.isDefined))
         InvocationValueImpl(thingsOpt.flatten.map(t => (t, context.next(Core.ExactlyOne(Core.LinkType(t))))))
       else
-        error("Func.unknownThing", displayName)  
+        error("Func.unknownThing", displayName)
     } else if (context.value.matchesType(Core.UnknownType)) {
       InvocationValueImpl(None)
     } else context.value.pType match {
-      case mt:ModelTypeBase => {
+      case mt: ModelTypeBase => {
         val pairs = context.value.cv.map(elem => (elem.get(mt), context.next(Core.ExactlyOne(elem))))
         InvocationValueImpl(pairs)
       }
       case _ => error("Func.notThing", displayName)
-    } 
+    }
   }
-  
-  def bundlesAndContextsForProp(prop:Property[_,_]):InvocationValue[(PropertyBundle, QLContext)] = {
-    
-    def wrapContexts(bundle:PropertyBundle):Iterable[(PropertyBundle, QLContext)] = {
+
+  def bundlesAndContextsForProp(prop: Property[_, _]): InvocationValue[(PropertyBundle, QLContext)] = {
+
+    def wrapContexts(bundle: PropertyBundle): Iterable[(PropertyBundle, QLContext)] = {
       context.value.cv.map(elem => (bundle, context.next(Core.ExactlyOne(elem))))
     }
-    
-    def withLexicalContext:Option[PropertyBundle] = {
+
+    def withLexicalContext: Option[PropertyBundle] = {
       for {
         parser <- context.parser
         lex <- parser.lexicalThing
-      }
-        yield lex
+      } yield lex
     }
 
     // Note that the elemContexts returned here are the same as the bundles. It isn't strictly clear that
     // that is correct -- conceptually, when we've walked back up the stack, we should be using the received
     // context as the elemContexts, I think. But things get weirdly multiplicative when we do that, and I'm
     // not sure how to correctly tame that.
-    def withCurrentContext(current:QLContext):Option[InvocationValue[(PropertyBundle, QLContext)]] = {
+    def withCurrentContext(current: QLContext): Option[InvocationValue[(PropertyBundle, QLContext)]] = {
       if (current.value.matchesType(Core.LinkType)) {
         val ids = current.value.flatMap(Core.LinkType)(Some(_))
         val thingsOpt = ids.map(state.anything(_))
@@ -335,7 +379,7 @@ private[ql] case class InvocationImpl(invokedOn:Thing, method:Thing,
         val tags = current.value.rawList(QL.UnknownNameType)
         Some(InvocationValueImpl(Tags.tagPropError(tags.mkString(", "), prop.displayName)))
       } else current.value.pType match {
-        case mt:ModelTypeBase => {
+        case mt: ModelTypeBase => {
           val pairs = current.value.cv.map(elem => (elem.get(mt), context.next(ExactlyOne(elem))))
           if (pairs.exists(_._1.hasProp(prop)))
             Some(InvocationValueImpl(pairs))
@@ -349,7 +393,7 @@ private[ql] case class InvocationImpl(invokedOn:Thing, method:Thing,
     // Walk recursively back the Context chain, until we find one that was a Thing (that is, a LinkType), or
     // we run out of Contexts. Note that we start with the one that was *already* tried, because we need to
     // inject lexical checking into this pathway:
-    def walkNonThingContexts(previous:QLContext):InvocationValue[(PropertyBundle, QLContext)] = {
+    def walkNonThingContexts(previous: QLContext): InvocationValue[(PropertyBundle, QLContext)] = {
       if (previous.parentOpt.isEmpty || previous.value.matchesType(LinkType)) {
         // Either we hit the end of the chain, or we hit a Link -- either way, time to stop:
         InvocationValueImpl(this, Future.successful(IVData(None, IVMetadata(returnType = Some(LinkType)))))
@@ -358,20 +402,19 @@ private[ql] case class InvocationImpl(invokedOn:Thing, method:Thing,
         val current = previous.parent
         withCurrentContext(current) match {
           case Some(result) => result
-          case None => walkNonThingContexts(current)
+          case None         => walkNonThingContexts(current)
         }
       }
     }
-    
+
     if (definingContext.isDefined) {
       // If there is a defining context, that is where we should be working from:
       val result = for {
         dc <- definingContext
         id <- dc.value.firstAs(Core.LinkType)
         thing <- state.anything(id)
-      }
-        yield InvocationValueImpl(wrapContexts(thing))
-        
+      } yield InvocationValueImpl(wrapContexts(thing))
+
       result.getOrElse(error("Func.notThing", displayName))
     } else {
       // No defining context -- does the received context have the property?
@@ -384,89 +427,107 @@ private[ql] case class InvocationImpl(invokedOn:Thing, method:Thing,
             case Some(bundle) if (bundle.hasProp(prop)) => InvocationValueImpl(wrapContexts(bundle))
             case _ => {
               context.value.pType match {
-                case mt:ModelTypeBase => {
+                case mt: ModelTypeBase => {
                   // If this bundle is a Model Value, walk up the context chain.
                   walkNonThingContexts(context)
                 }
                 case _ => {
-                  InvocationValueImpl(this, Future.successful(IVData(None, IVMetadata(returnType = Some(LinkType)))))                
+                  InvocationValueImpl(this, Future.successful(IVData(None, IVMetadata(returnType = Some(LinkType)))))
                 }
               }
             }
-          }          
+          }
         }
       }
     }
   }
-  
-  def definingContextAsProperty:InvocationValue[Property[_,_]] = {
+
+  def definingContextAsProperty: InvocationValue[Property[_, _]] = {
     definingContext match {
       case Some(defining) => {
         if (!defining.value.matchesType(Core.LinkType))
           error("Func.notThing", displayName)
         else {
-          val ids:Iterable[ThingId] = defining.value.flatMap(Core.LinkType)(oid => Some(AsOID(oid)))
-          val propOpts:Iterable[Option[Property[_,_]]] = ids.map(state.prop(_))
+          val ids: Iterable[ThingId] = defining.value.flatMap(Core.LinkType)(oid => Some(AsOID(oid)))
+          val propOpts: Iterable[Option[Property[_, _]]] = ids.map(state.prop(_))
           if (propOpts.forall(_.isDefined)) {
             InvocationValueImpl(propOpts.flatten)
           } else
             error("Func.notProp", displayName)
-        }          
+        }
       }
       case None => error("Func.missingDefiningContext", displayName)
-    }    
+    }
   }
-  
-  def definingContextAsPropertyOf[VT](targetType:PType[VT]):InvocationValue[Property[VT,_]] = {
+
+  def definingContextAsPropertyOf[VT](targetType: PType[VT]): InvocationValue[Property[VT, _]] = {
     definingContext match {
       case Some(defining) => {
         if (!defining.value.matchesType(Core.LinkType))
           error("Func.notThing", displayName)
         else {
-          val ids:Iterable[ThingId] = defining.value.flatMap(Core.LinkType)(oid => Some(AsOID(oid)))
-          val propOpts:Iterable[Option[Property[VT,_]]] = ids.map(state.prop(_).flatMap(prop => prop.confirmType(targetType)))
+          val ids: Iterable[ThingId] = defining.value.flatMap(Core.LinkType)(oid => Some(AsOID(oid)))
+          val propOpts: Iterable[Option[Property[VT, _]]] =
+            ids.map(state.prop(_).flatMap(prop => prop.confirmType(targetType)))
           if (propOpts.forall(_.isDefined)) {
             InvocationValueImpl(propOpts.flatten)
           } else
             error("Func.notProp", displayName)
-    }          
+        }
       }
       case None => error("Func.missingDefiningContext", displayName)
-    }  
+    }
   }
-  
-  def definingContextAsOptionalPropertyOf[VT](targetType:PType[VT]):InvocationValue[Option[Property[VT,_]]] = {
+
+  def definingContextAsOptionalPropertyOf[VT](targetType: PType[VT]): InvocationValue[Option[Property[VT, _]]] = {
     definingContext match {
       case Some(defining) => {
         if (!defining.value.matchesType(Core.LinkType))
           error("Func.notThing", displayName)
         else {
-          val ids:Iterable[ThingId] = defining.value.flatMap(Core.LinkType)(oid => Some(AsOID(oid)))
-          val propOpts:Iterable[Option[Property[VT,_]]] = ids.map(state.prop(_).flatMap(prop => prop.confirmType(targetType)))
+          val ids: Iterable[ThingId] = defining.value.flatMap(Core.LinkType)(oid => Some(AsOID(oid)))
+          val propOpts: Iterable[Option[Property[VT, _]]] =
+            ids.map(state.prop(_).flatMap(prop => prop.confirmType(targetType)))
           if (propOpts.forall(_.isDefined)) {
             InvocationValueImpl(propOpts)
           } else
             error("Func.notProp", displayName)
-        }          
+        }
       }
       case None => InvocationValueImpl(Some(None))
-    }  
+    }
   }
-  
-  def process(name:String, processContext:QLContext = context):InvocationValue[QValue] = {
-    val resultFut = sig.getParam(name).process(context.parser.get, processContext).flatMap { raw =>
+
+  def processParamFrom(
+    name: String,
+    context: QLContext,
+    processContext: QLContext
+  ): Future[QLContext] = {
+    sig.getParam(name).process(getProcessor(context), processContext)
+  }
+
+  def process(
+    name: String,
+    processContext: QLContext = context
+  ): InvocationValue[QValue] = {
+    val resultFut = processParamFrom(name, context, processContext).flatMap { raw =>
       val processed = raw.value
       processed.firstAs(QL.ErrorTextType) match {
         // If there was an error, keep the error, and stop processing:
         case Some(errorText) => Future.failed(new PublicException("General.public", errorText.text))
-        case None => Future.successful(Some(processed))
+        case None            => Future.successful(Some(processed))
       }
     }
     InvocationValueImpl(inv, resultFut.map(IVData(_)))
   }
-  
-  private def processAsBase[VT](name:String, typeName: => String, ret:QValue => Seq[VT], processContext:QLContext = context):InvocationValue[VT] = {
-    val resultFut = sig.getParam(name).process(context.parser.get, processContext).flatMap { raw =>
+
+  private def processAsBase[VT](
+    name: String,
+    typeName: => String,
+    ret: QValue => Seq[VT],
+    processContext: QLContext = context
+  ): InvocationValue[VT] = {
+    val resultFut = processParamFrom(name, context, processContext).flatMap { raw =>
       val processed = raw.value
       processed.firstAs(QL.ErrorTextType) match {
         // If there was an error, keep the error, and stop processing:
@@ -475,68 +536,79 @@ private[ql] case class InvocationImpl(invokedOn:Thing, method:Thing,
           try {
             Future.successful(ret(processed))
           } catch {
-            case ex:Exception => Future.failed(PublicException("Func.paramWrongType", displayName, name, typeName, processed.pType.displayName))  
+            case ex: Exception => Future.failed(PublicException(
+                "Func.paramWrongType",
+                displayName,
+                name,
+                typeName,
+                processed.pType.displayName
+              ))
           }
         }
       }
     }
     InvocationValueImpl(inv, resultFut.map(IVData(_)))
   }
-  
-  def processAs[VT](name:String, pt:PType[VT], processContext:QLContext = context):InvocationValue[VT] = {
+
+  def processAs[VT](
+    name: String,
+    pt: PType[VT],
+    processContext: QLContext = context
+  ): InvocationValue[VT] = {
     processAsBase(name, pt.displayName, (_.rawList(pt)), processContext)
   }
-  
-  def processAsOpt[VT](name:String, pt:PType[VT], processContext:QLContext = context):InvocationValue[Option[VT]] = {
+
+  def processAsOpt[VT](
+    name: String,
+    pt: PType[VT],
+    processContext: QLContext = context
+  ): InvocationValue[Option[VT]] = {
     processAsBase(name, pt.displayName, (qv => Some(qv.firstAs(pt)).toSeq), processContext)
   }
-  
-  def processAsList[VT](name:String, pt:PType[VT], processContext:QLContext = context):InvocationValue[List[VT]] = {
+
+  def processAsList[VT](
+    name: String,
+    pt: PType[VT],
+    processContext: QLContext = context
+  ): InvocationValue[List[VT]] = {
     processAsBase(name, pt.displayName, (qv => List(qv.rawList(pt))), processContext)
   }
-  
-  def rawParam(name:String):InvocationValue[Option[QLExp]] = {
+
+  def rawParam(name: String): InvocationValue[Option[QLExp]] = {
     InvocationValueImpl(inv, Future.successful(IVData(Some(sig.getParam(name).exp))))
   }
-  
-  def rawRequiredParam(name:String):InvocationValue[QLExp] = {
+
+  def rawRequiredParam(name: String): InvocationValue[QLExp] = {
     sig.getParam(name).exp match {
       case Some(exp) => InvocationValueImpl(inv, Future.successful(IVData(Some(exp))))
-      case None => error("Func.missingNamedParam", displayName, name)
+      case None      => error("Func.missingNamedParam", displayName, name)
     }
   }
-  
-  def processParam(paramNum:Int, processContext:QLContext = context):InvocationValue[QValue] = {
+
+  def getProcessor(context: QLContext): QLProcessor = {
+    context.parser.map(_.processor).getOrElse(new QLProcessor(context))
+  }
+
+  def processExp(
+    exp: QLExp,
+    context: QLContext,
+    processContext: QLContext
+  ): Future[QLContext] = {
+    getProcessor(context).processExp(exp, processContext)
+  }
+
+  def processParam(
+    paramNum: Int,
+    processContext: QLContext = context
+  ): InvocationValue[QValue] = {
     paramsOpt match {
       case Some(params) if (params.length >= (paramNum + 1)) => {
-        val resultFut = context.parser.get.processExp(params(paramNum).exp, processContext).flatMap { raw =>
+        val resultFut = processExp(params(paramNum).exp, context, processContext).flatMap { raw =>
           val processed = raw.value
           processed.firstAs(QL.ErrorTextType) match {
             // If there was an error, keep the error, and stop processing:
             case Some(errorText) => Future.failed(new PublicException("General.public", errorText))
-            case None => Future.successful(Some(processed))
-          }
-        }
-        InvocationValueImpl(inv, resultFut.map(IVData(_)))
-      }
-      case _ => error("Func.missingParam", displayName)
-    }    
-  }
-  
-  private def processParamFirstGuts[VT](paramNum:Int, pt:PType[VT], processContext:QLContext = context)(onEmpty: => Future[Iterable[VT]]):InvocationValue[VT] = 
-  {
-    paramsOpt match {
-      case Some(params) if (params.length >= (paramNum + 1)) => {
-        val resultFut:Future[Iterable[VT]] = context.parser.get.processExp(params(paramNum).exp, processContext).flatMap { raw =>
-          val processed = raw.value
-          if (processed.isEmpty)
-            onEmpty
-          else processed.firstAs(QL.ErrorTextType) match {
-            case Some(errorText) => Future.failed(new PublicException("General.public", errorText))
-            case None => processed.firstAs(pt) match {
-              case Some(v) => Future.successful(Some(v))
-              case None => Future.failed(PublicException("Func.paramWrongType", displayName, paramNum.toString, pt.displayName, processed.pType.displayName))                
-            }
+            case None            => Future.successful(Some(processed))
           }
         }
         InvocationValueImpl(inv, resultFut.map(IVData(_)))
@@ -544,16 +616,59 @@ private[ql] case class InvocationImpl(invokedOn:Thing, method:Thing,
       case _ => error("Func.missingParam", displayName)
     }
   }
-  
-  def processParamFirstAs[VT](paramNum:Int, pt:PType[VT], processContext:QLContext = context):InvocationValue[VT] = {
-    processParamFirstGuts(paramNum, pt, processContext) { 
+
+  private def processParamFirstGuts[VT](
+    paramNum: Int,
+    pt: PType[VT],
+    processContext: QLContext = context
+  )(
+    onEmpty: => Future[Iterable[VT]]
+  ): InvocationValue[VT] = {
+    paramsOpt match {
+      case Some(params) if (params.length >= (paramNum + 1)) => {
+        val resultFut: Future[Iterable[VT]] =
+          processExp(params(paramNum).exp, context, processContext).flatMap { raw =>
+            val processed = raw.value
+            if (processed.isEmpty)
+              onEmpty
+            else processed.firstAs(QL.ErrorTextType) match {
+              case Some(errorText) => Future.failed(new PublicException("General.public", errorText))
+              case None => processed.firstAs(pt) match {
+                  case Some(v) => Future.successful(Some(v))
+                  case None => Future.failed(PublicException(
+                      "Func.paramWrongType",
+                      displayName,
+                      paramNum.toString,
+                      pt.displayName,
+                      processed.pType.displayName
+                    ))
+                }
+            }
+          }
+        InvocationValueImpl(inv, resultFut.map(IVData(_)))
+      }
+      case _ => error("Func.missingParam", displayName)
+    }
+  }
+
+  def processParamFirstAs[VT](
+    paramNum: Int,
+    pt: PType[VT],
+    processContext: QLContext = context
+  ): InvocationValue[VT] = {
+    processParamFirstGuts(paramNum, pt, processContext) {
       Future.failed(PublicException("Func.emptyParamValue", displayName))
     }
   }
-  
-  def processParamFirstOr[VT](paramNum:Int, pt:PType[VT], default:VT, processContext:QLContext = context):InvocationValue[VT] = {
+
+  def processParamFirstOr[VT](
+    paramNum: Int,
+    pt: PType[VT],
+    default: VT,
+    processContext: QLContext = context
+  ): InvocationValue[VT] = {
     paramsOpt match {
-      case Some(params) if (params.length >= (paramNum + 1)) => 
+      case Some(params) if (params.length >= (paramNum + 1)) =>
         processParamFirstGuts(paramNum, pt, processContext) {
           // Iff the result of the param was empty, return the default
           Future(Some(default))
@@ -561,8 +676,12 @@ private[ql] case class InvocationImpl(invokedOn:Thing, method:Thing,
       case _ => wrap(default)
     }
   }
-  
-  def processParamNofM(paramNum:Int, expectedParams:Int, processContext:QLContext = context):InvocationValue[QValue] = {
+
+  def processParamNofM(
+    paramNum: Int,
+    expectedParams: Int,
+    processContext: QLContext = context
+  ): InvocationValue[QValue] = {
     if (numParams < (expectedParams - 1))
       InvocationValueImpl(new PublicException("Func.insufficientParams", displayName, (expectedParams - 1)))
     else {
@@ -574,23 +693,23 @@ private[ql] case class InvocationImpl(invokedOn:Thing, method:Thing,
         processParam(paramNum - 1, processContext)
     }
   }
-  
-  def rawParam(paramNum:Int):InvocationValue[QLExp] = {
+
+  def rawParam(paramNum: Int): InvocationValue[QLExp] = {
     paramsOpt match {
       case Some(params) if (params.length >= (paramNum - 1)) => InvocationValueImpl(Some(params(paramNum).exp))
-      case _ => error("Func.missingParam", displayName)
+      case _                                                 => error("Func.missingParam", displayName)
     }
   }
-  
-  def WarningValue(msg:String) = QL.WarningValue(msg)
-  
+
+  def WarningValue(msg: String) = QL.WarningValue(msg)
+
   /**
    * The "primary" context of this invocation. This is an exact synonym for receivedContext, and is the
-   * one you usually care about. 
+   * one you usually care about.
    */
-  def context:QLContext = receivedContext
-  
-  implicit lazy val state:SpaceState = {
+  def context: QLContext = receivedContext
+
+  implicit lazy val state: SpaceState = {
     val param = sig.getParam("_space")
     param.exp match {
       case Some(exp) => {
@@ -598,7 +717,7 @@ private[ql] case class InvocationImpl(invokedOn:Thing, method:Thing,
         // always be a Future, and 99.99% of the time when we use _space it's going to be synchronous,
         // but we can't actually guarantee that. Hmm. Is there any way to force synchrony here -- to
         // only allow synchronous functions?
-        val processed = awaitHack(param.process(context.parser.get, context)).value
+        val processed = awaitHack(param.process(getProcessor(context), context)).value
         processed.firstAs(LinkType) match {
           case Some(link) => {
             context.state.getApp(link).getOrElse(throw new PublicException("QL.invocation.notASpace"))
@@ -610,13 +729,13 @@ private[ql] case class InvocationImpl(invokedOn:Thing, method:Thing,
       case _ => context.state
     }
   }
-  
+
   def parser = context.parser
-  
+
   def lexicalThing = parser.flatMap(_.lexicalThing)
-    
-  def numParams:Int = paramsOpt match {
+
+  def numParams: Int = paramsOpt match {
     case Some(params) => params.length
-    case None => 0
+    case None         => 0
   }
 }

--- a/querki/scalajvm/app/querki/ql/QLEcot.scala
+++ b/querki/scalajvm/app/querki/ql/QLEcot.scala
@@ -21,50 +21,69 @@ import querki.values.{CutProcessing, ElemValue, EmptyContext, IsErrorType, QLCon
 object MOIDs extends EcotIds(24) {
   val SelfMethodOID = sysId(75)
   val CodeMethodOID = sysId(77)
-  
+
   val IsBoundFunctionOID = moid(1)
 }
 
-private [ql] trait QLInternals extends EcologyInterface {
-  def qlProfilers:QLProfilers
+private[ql] trait QLInternals extends EcologyInterface {
+  def qlProfilers: QLProfilers
 }
 
 trait QLTestTools extends EcologyInterface {
-  def serializeContextCore(qv:QValue, bindings:Map[String, QValue])(implicit state:SpaceState):String
+
+  def serializeContextCore(
+    qv: QValue,
+    bindings: Map[String, QValue]
+  )(implicit
+    state: SpaceState
+  ): String
 }
 
-class QLEcot(e:Ecology) extends QuerkiEcot(e) with QL with QLInternals with QLTestTools with querki.core.WithQL
-  with querki.core.CollectionBase
-  with querki.core.MethodDefs with querki.core.TextTypeBasis with querki.core.NameUtils with querki.core.NameTypeBasis 
-  with querki.basic.PlainTextBaseType
-{
+class QLEcot(e: Ecology)
+  extends QuerkiEcot(e)
+     with QL
+     with QLInternals
+     with QLTestTools
+     with querki.core.WithQL
+     with querki.core.CollectionBase
+     with querki.core.MethodDefs
+     with querki.core.TextTypeBasis
+     with querki.core.NameUtils
+     with querki.core.NameTypeBasis
+     with querki.basic.PlainTextBaseType {
   import MOIDs._
-  
+
   lazy val HtmlUI = interface[querki.html.HtmlUI]
   lazy val Profiler = interface[querki.tools.Profiler]
-  
+
   lazy val parserCreateProfiler = Profiler.createHandle("QLEcot.parserCreate")
   lazy val parserProcessProfiler = Profiler.createHandle("QLEcot.parserProcess")
   lazy val parserProcessMethodProfiler = Profiler.createHandle("QLEcot.parserProcessMethod")
-  
+
   // This is provided as a service for the QLParsers:
   lazy val qlProfilers = new QLProfilers
-  
+
   def QL = this
-  
-  /***********************************************
+
+  /**
+   * *********************************************
    * PUBLIC API
-   ***********************************************/
-  
-  def qvUnpack(data:IVData[QValue]):QValue = {
+   * *********************************************
+   */
+
+  def qvUnpack(data: IVData[QValue]): QValue = {
     val qvs = data.vs
     val returnType = data.metadata.returnType
     val preferredColl = data.metadata.preferredColl
-    
+
     collectQVs(qvs, returnType, preferredColl)
   }
-  
-  def collectQVs(qvs:Iterable[QValue], returnType:Option[PType[_]], preferredColl:Option[Collection]):QValue = {
+
+  def collectQVs(
+    qvs: Iterable[QValue],
+    returnType: Option[PType[_]],
+    preferredColl: Option[Collection]
+  ): QValue = {
     // This code originally lived in QLContext.collect(). It is still kind of iffy, but is
     // conceptually Iterable[QValue].flatten:
     val pt = {
@@ -91,7 +110,7 @@ class QLEcot(e:Ecology) extends QuerkiEcot(e) with QL with QLInternals with QLTe
     // Rationalize the Collection. If the Collection we got from the invocation works with the number of
     // elements, keep it; otherwise, slam it to something sensible.
     // TODO: this mechanism needs to be generalized.
-    val newCT = 
+    val newCT =
       if (raw.isEmpty) {
         if (ct == Core.ExactlyOne)
           Core.Optional
@@ -107,139 +126,179 @@ class QLEcot(e:Ecology) extends QuerkiEcot(e) with QL with QLInternals with QLTe
         else
           ct
       }
-    newCT.makePropValue(raw, pt)    
+    newCT.makePropValue(raw, pt)
   }
-  
-  def inv2QValueImpl(invRaw:InvocationValue[QValue]):QFut = {
+
+  def inv2QValueImpl(invRaw: InvocationValue[QValue]): QFut = {
     val inv = invRaw.asInstanceOf[InvocationValueImpl[QValue]]
     inv.fut.map(data => qvUnpack(data))
   }
-  
-  def process(input:QLText, ci:QLContext, invOpt:Option[Invocation] = None, 
-      lexicalThing:Option[PropertyBundle] = None, lexicalProp:Option[AnyProp] = None):Future[Wikitext] = 
-  {
+
+  def process(
+    input: QLText,
+    ci: QLContext,
+    invOpt: Option[Invocation] = None,
+    lexicalThing: Option[PropertyBundle] = None,
+    lexicalProp: Option[AnyProp] = None
+  ): Future[Wikitext] = {
     val parser = parserCreateProfiler.profile { new QLParser(input, ci, invOpt, lexicalThing, lexicalProp) }
     parserProcessProfiler.profile { parser.process }
   }
-  
-  def processMethod(input:QLText, ci:QLContext, invOpt:Option[Invocation] = None, 
-      lexicalThing:Option[PropertyBundle] = None, lexicalProp:Option[AnyProp] = None):Future[QValue] = 
-  {
+
+  def processMethod(
+    input: QLText,
+    ci: QLContext,
+    invOpt: Option[Invocation] = None,
+    lexicalThing: Option[PropertyBundle] = None,
+    lexicalProp: Option[AnyProp] = None
+  ): Future[QValue] = {
     val parser = parserCreateProfiler.profile { new QLParser(input, ci, invOpt, lexicalThing, lexicalProp) }
     parserProcessMethodProfiler.profile { parser.processMethod.map(_.value) }
   }
-  
-  def processMethodToWikitext(input:QLText, ci:QLContext, invOpt:Option[Invocation] = None, 
-      lexicalThing:Option[PropertyBundle] = None, lexicalProp:Option[AnyProp] = None,
-      initialBindings:Option[Map[String, QValue]] = None):Future[Wikitext] = 
-  {
-    val parser = parserCreateProfiler.profile { new QLParser(input, ci, invOpt, lexicalThing, lexicalProp, initialBindings) }
+
+  def processMethodToWikitext(
+    input: QLText,
+    ci: QLContext,
+    invOpt: Option[Invocation] = None,
+    lexicalThing: Option[PropertyBundle] = None,
+    lexicalProp: Option[AnyProp] = None,
+    initialBindings: Option[Map[String, QValue]] = None
+  ): Future[Wikitext] = {
+    val parser =
+      parserCreateProfiler.profile { new QLParser(input, ci, invOpt, lexicalThing, lexicalProp, initialBindings) }
     parserProcessMethodProfiler.profile { parser.processMethodToWikitext }
   }
-  
-  def parseMethod(input:String):Option[QLPhrase] =
-  {
+
+  def parseMethod(input: String): Option[QLPhrase] = {
     // Since we're just parsing, we shouldn't need a context:
     val parser = parserCreateProfiler.profile { new QLParser(QLText(input), EmptyContext(ecology)) }
     parser.parsePhrase()
   }
-  
+
   lazy val ExactlyOneCut = new ExactlyOneBase(UnknownOID) {
-    override def makePropValue(cv:Iterable[ElemValue], elemT:PType[_]):QValue = new ExactlyOnePropValue(cv.toList, this, elemT) with CutProcessing
+
+    override def makePropValue(
+      cv: Iterable[ElemValue],
+      elemT: PType[_]
+    ): QValue = new ExactlyOnePropValue(cv.toList, this, elemT) with CutProcessing
   }
-  
+
   lazy val EmptyListCutColl = new QListBase(UnknownOID, emptyProps) {
-    def apply() = new QListPropValue(List.empty, this, Core.UnknownType) with CutProcessing  
+    def apply() = new QListPropValue(List.empty, this, Core.UnknownType) with CutProcessing
   }
   def EmptyListCut() = EmptyListCutColl()
 
-  object ErrorTextType extends PlainTextType(UnknownOID,
-    toProps(
-      setName("Error Text")
-    )) with PTypeBuilder[PlainText,String] with IsErrorType {
-  }
+  object ErrorTextType
+    extends PlainTextType(
+      UnknownOID,
+      toProps(
+        setName("Error Text")
+      )
+    )
+       with PTypeBuilder[PlainText, String]
+       with IsErrorType {}
 
-  def WarningValue(msg:String) = ExactlyOneCut(ErrorTextType("{{_warning:" + msg + "}}"))
-  
-  def ErrorValue(msg:String) = {
+  def WarningValue(msg: String) = ExactlyOneCut(ErrorTextType("{{_warning:" + msg + "}}"))
+
+  def ErrorValue(msg: String) = {
     try {
       throw new Exception("dummy")
     } catch {
-      case e:Exception => QLog.error(s"Displaying error $msg; stack trace:\n${e.getStackTrace.toString()}")  
+      case e: Exception => QLog.error(s"Displaying error $msg; stack trace:\n${e.getStackTrace.toString()}")
     }
     WarningValue(msg)
   }
-  
-  def WikitextValue(wikitext:Wikitext):QValue = ExactlyOne(ParsedTextType(wikitext))
-  
+
+  def WikitextValue(wikitext: Wikitext): QValue = ExactlyOne(ParsedTextType(wikitext))
+
   val QLTag = "QL -- Parsing and Running Expressions"
-  
-  /***********************************************
+
+  /**
+   * *********************************************
    * Serialization / Deserialization
-   * 
+   *
    * These functions are used by systems such as _QLButton(), to embed the current state
    * of processing into HTML. They render an Invocation into an opaque String, and back again.
    */
-  
+
   // findBindingsIn() is a collection of functions to traverse a QLExp and find all of the
   // bindings referred to in it, so we know what we need to serialize. Conceptually it's a
   // typeclass, but since we only need it here, I'm not bothering with the TC boilerplate.
-  private def findBindingsInSeq[T](ts:Seq[T])(getter:T => Set[String]):Set[String] = {
+  private def findBindingsInSeq[T](ts: Seq[T])(getter: T => Set[String]): Set[String] = {
     (Set.empty[String] /: ts) { (set, t) =>
       set ++ getter(t)
     }
   }
-  
-  private def findBindingsIn(exp:QLExp):Set[String] = {
+
+  private def findBindingsIn(exp: QLExp): Set[String] = {
     findBindingsInSeq(exp.phrases)(findBindingsIn(_))
   }
-  private def findBindingsIn(phrase:QLPhrase):Set[String] = {
+
+  private def findBindingsIn(phrase: QLPhrase): Set[String] = {
     findBindingsInSeq(phrase.ops)(findBindingsIn(_))
   }
-  private def findBindingsIn(stage:QLStage):Set[String] = {
+
+  private def findBindingsIn(stage: QLStage): Set[String] = {
     stage match {
       case QLCall(name, methodNameOpt, paramsOpt, _) => {
-        findBindingsIn(name) ++ 
+        findBindingsIn(name) ++
           methodNameOpt.map(findBindingsIn(_)).getOrElse(Set.empty) ++
           paramsOpt.map { params =>
             findBindingsInSeq(params)(param => findBindingsIn(param.exp))
           }.getOrElse(Set.empty)
       }
       case QLTextStage(contents, _) => findBindingsIn(contents)
-      case QLExpStage(exp) => findBindingsIn(exp)
-      case QLListLiteral(exps) => findBindingsInSeq(exps)(findBindingsIn(_))
-      case QLNumber(_) => Set.empty
-      case QLTextBlockLiteral(_) => Set.empty
+      case QLExpStage(exp)          => findBindingsIn(exp)
+      case QLListLiteral(exps)      => findBindingsInSeq(exps)(findBindingsIn(_))
+      case QLNumber(_)              => Set.empty
+      case QLTextBlockLiteral(_)    => Set.empty
     }
   }
-  private def findBindingsIn(contents:ParsedQLText):Set[String] = {
+
+  private def findBindingsIn(contents: ParsedQLText): Set[String] = {
     findBindingsInSeq(contents.parts) { part =>
       part match {
-        case UnQLText(_) => Set.empty
+        case UnQLText(_)      => Set.empty
         case QLLink(contents) => findBindingsIn(contents)
-        case QLExp(exp) => findBindingsIn(QLExp(exp))
-      }          
-    }    
+        case QLExp(exp)       => findBindingsIn(QLExp(exp))
+      }
+    }
   }
-  private def findBindingsIn(name:QLName):Set[String] = {
+
+  private def findBindingsIn(name: QLName): Set[String] = {
     // This is where we actually *find* the bindings
     name match {
       case QLSafeName(_) | QLDisplayName(_) | QLBindingDef(_, _, _) | QLThingId(_) => Set.empty
-      case QLBinding(binding) => Set(binding)
+      case QLBinding(binding)                                                      => Set(binding)
     }
   }
-  
-  case class EmbeddedBinding(pTypeId:OID, cTypeId:OID, serialized:String)
-  case class EmbeddableContext(qvpType:OID, qvcType:OID, serializedQV:String, bindingsSerialized:Map[String, EmbeddedBinding])
-  
+
+  case class EmbeddedBinding(
+    pTypeId: OID,
+    cTypeId: OID,
+    serialized: String
+  )
+
+  case class EmbeddableContext(
+    qvpType: OID,
+    qvcType: OID,
+    serializedQV: String,
+    bindingsSerialized: Map[String, EmbeddedBinding]
+  )
+
   // These guts are broken out for testing:
-  def serializeContextCore(qv:QValue, bindings:Map[String, QValue])(implicit state:SpaceState):String = {
+  def serializeContextCore(
+    qv: QValue,
+    bindings: Map[String, QValue]
+  )(implicit
+    state: SpaceState
+  ): String = {
     val serializedQV = qv.serialize(qv.pType)
     // We need to store each binding with its PType and serialized Value:
-    val bindingsSerialized:Map[String, EmbeddedBinding] = bindings.map { case (k, v) =>
+    val bindingsSerialized: Map[String, EmbeddedBinding] = bindings.map { case (k, v) =>
       (k -> EmbeddedBinding(v.pType.id, v.cType.id, v.serialize(v.pType)))
     }
-      
+
     // Now build the structure we're actually going to serialize...
     val embeddable = EmbeddableContext(qv.pType.id, qv.cType.id, serializedQV, bindingsSerialized)
     // ... pickle that...
@@ -247,43 +306,50 @@ class QLEcot(e:Ecology) extends QuerkiEcot(e) with QL with QLInternals with QLTe
     val arr = Array.ofDim[Byte](buf.remaining())
     buf.get(arr)
     // and turn it into an opaque embeddable String:
-    Base64.Encoder(arr).toBase64    
+    Base64.Encoder(arr).toBase64
   }
-  
-  def serializeContext(inv:Invocation, qlParamNameOpt:Option[String]):InvocationValue[String] = {
+
+  def serializeContext(
+    inv: Invocation,
+    qlParamNameOpt: Option[String]
+  ): InvocationValue[String] = {
     try {
       implicit val state = inv.state
-      // Note: we are explicitly assuming that there is only one implementation of Invocation! 
+      // Note: we are explicitly assuming that there is only one implementation of Invocation!
       val invImpl = inv.asInstanceOf[InvocationImpl]
-      
+
       // First, serialize the received context. That's the easy bit:
       val context = inv.context
       val qv = context.value
-  
+
       // Next, figure out which bindings are actually being *used* by the QL expression we're
       // embedding:
-      def findBindingValue(inv:Invocation, name:String):Option[QValue] = {
+      def findBindingValue(
+        inv: Invocation,
+        name: String
+      ): Option[QValue] = {
         for {
           parser <- inv.context.parser
-          scopes = inv.context.scopes(parser)
+          scopes = inv.context.scopes(parser.processor)
           bound <- scopes.lookup(name)
-        }
-          yield bound
+        } yield bound
       }
-      def bindingValues(inv:Invocation, boundNames:Set[String]):Map[String, QValue] = {
+      def bindingValues(
+        inv: Invocation,
+        boundNames: Set[String]
+      ): Map[String, QValue] = {
         (Map.empty[String, QValue] /: boundNames) { (m, name) =>
           findBindingValue(inv, name).map(v => m + (name -> v)).getOrElse(m)
         }
       }
-      
+
       val bindingsOpt = for {
         qlParamName <- qlParamNameOpt
         exp <- invImpl.sig.getParam(qlParamName).exp
         boundNames = findBindingsIn(exp)
-      }
-        yield bindingValues(inv, boundNames)
+      } yield bindingValues(inv, boundNames)
       val bindings = bindingsOpt.getOrElse(Map.empty)
-      
+
       inv.wrap(serializeContextCore(qv, bindings))
     } catch {
       case SerializationException(tpe) => {
@@ -291,8 +357,8 @@ class QLEcot(e:Ecology) extends QuerkiEcot(e) with QL with QLInternals with QLTe
       }
     }
   }
-  
-  def deserializeContext(str:String)(implicit state:SpaceState):(QValue, Map[String, QValue]) = {
+
+  def deserializeContext(str: String)(implicit state: SpaceState): (QValue, Map[String, QValue]) = {
     val byteArray = Base64.Decoder(str).toByteArray
     val embedded = Unpickle[EmbeddableContext].fromBytes(java.nio.ByteBuffer.wrap(byteArray))
     val pType = state.typ(embedded.qvpType)
@@ -305,21 +371,32 @@ class QLEcot(e:Ecology) extends QuerkiEcot(e) with QL with QLInternals with QLTe
     }
     (qv, bindings)
   }
-  
-  /***********************************************
+
+  /**
+   * *********************************************
    * TYPES
-   ***********************************************/
+   * *********************************************
+   */
 
   /**
    * This is a fake PType, used when we encounter a name we don't know.
    */
-  lazy val UnknownNameType = new NameTypeBase(UnknownOID, 
+  lazy val UnknownNameType = new NameTypeBase(
+    UnknownOID,
     toProps(
       setName("_unknownNameType"),
       Categories(QLTag),
-      Summary("This is an error type produced when your expression contains an unknown name"))) 
-  {
-    def doWikify(context:QLContext)(v:String, displayOpt:Option[Wikitext] = None, lexicalThing:Option[PropertyBundle] = None) = {
+      Summary("This is an error type produced when your expression contains an unknown name")
+    )
+  ) {
+
+    def doWikify(
+      context: QLContext
+    )(
+      v: String,
+      displayOpt: Option[Wikitext] = None,
+      lexicalThing: Option[PropertyBundle] = None
+    ) = {
       Future.successful(Wikitext("{{_unknownName:") + nameToLink(context)(v, displayOpt) + Wikitext("}}"))
     }
   }
@@ -327,56 +404,83 @@ class QLEcot(e:Ecology) extends QuerkiEcot(e) with QL with QLInternals with QLTe
   /**
    * This is a fake PType, which exists so that we can persist embedded Texts in the pipeline.
    */
-  lazy val ParsedTextType = new SystemType[Wikitext](UnknownOID, 
+  lazy val ParsedTextType = new SystemType[Wikitext](
+    UnknownOID,
     toProps(
       setName("Parsed Text Type"),
       Categories(QLTag),
-      Summary("This is an internal Text Type that results from the system parsing some Text")))
-    with SimplePTypeBuilder[Wikitext] with querki.core.IsTextType
-  {
+      Summary("This is an internal Text Type that results from the system parsing some Text")
+    )
+  ) with SimplePTypeBuilder[Wikitext] with querki.core.IsTextType {
+
     // We didn't originally permit serialization of Wikitext, but do now for Notifications. Since we want to
     // retain the Wikitext's structure properly, we are serializing it using upickle, since that's the
     // well-established way we handle it over the wire. It's a bit inefficient, but should be liveable.
-    def doDeserialize(v:String)(implicit state:SpaceState) = {
+    def doDeserialize(v: String)(implicit state: SpaceState) = {
       import upickle.default._
       read[Wikitext](v)
     }
-    def doSerialize(v:Wikitext)(implicit state:SpaceState) = {
+
+    def doSerialize(v: Wikitext)(implicit state: SpaceState) = {
       import upickle.default._
       write[Wikitext](v)
     }
-    
-    def doWikify(context:QLContext)(v:Wikitext, displayOpt:Option[Wikitext] = None, lexicalThing:Option[PropertyBundle] = None) = 
+
+    def doWikify(
+      context: QLContext
+    )(
+      v: Wikitext,
+      displayOpt: Option[Wikitext] = None,
+      lexicalThing: Option[PropertyBundle] = None
+    ) =
       Future.successful(v)
-    override def doToUrlParam(v:Wikitext, raw:Boolean)(implicit state:SpaceState):String = {
+
+    override def doToUrlParam(
+      v: Wikitext,
+      raw: Boolean
+    )(implicit
+      state: SpaceState
+    ): String = {
       if (raw)
         s"${v.plaintext}"
       else
         s"""""${v.plaintext}"""""
     }
-  
-    override def doComp(context:QLContext)(left:Wikitext, right:Wikitext):Boolean = { left.plaintext.toLowerCase < right.plaintext.toLowerCase }
-    override def doMatches(left:Wikitext, right:Wikitext):Boolean = { left.plaintext == right.plaintext }
-    override def doDebugRender(context:QLContext)(v:Wikitext) = v.contents.map(_.internal).mkString
-  
-    def doDefault(implicit state:SpaceState) = Wikitext("")
-    def wrap(raw:String):valType = Wikitext(raw)
+
+    override def doComp(
+      context: QLContext
+    )(
+      left: Wikitext,
+      right: Wikitext
+    ): Boolean = { left.plaintext.toLowerCase < right.plaintext.toLowerCase }
+
+    override def doMatches(
+      left: Wikitext,
+      right: Wikitext
+    ): Boolean = { left.plaintext == right.plaintext }
+    override def doDebugRender(context: QLContext)(v: Wikitext) = v.contents.map(_.internal).mkString
+
+    def doDefault(implicit state: SpaceState) = Wikitext("")
+    def wrap(raw: String): valType = Wikitext(raw)
     // This is a transient PType, so we don't care:
-    def doComputeMemSize(v:Wikitext):Int = 0
-    
+    def doComputeMemSize(v: Wikitext): Int = 0
+
     // Parsed Text can be coerced to conventional Text types:
-    override def canCoerceTo(other:PType[_]):Boolean = {
+    override def canCoerceTo(other: PType[_]): Boolean = {
       other match {
-        case et:IsErrorType => false
-        case itt:IsTextType => true
-        case _ => false
+        case et: IsErrorType => false
+        case itt: IsTextType => true
+        case _               => false
       }
     }
-    
-    override def coerceTo(other:PType[_], elem:ElemValue):ElemValue = {
+
+    override def coerceTo(
+      other: PType[_],
+      elem: ElemValue
+    ): ElemValue = {
       other match {
-        case et:IsErrorType => throw new Exception(s"PType $displayName can not be coerced to ${other.displayName}!")
-        case itt:IsTextType => {
+        case et: IsErrorType => throw new Exception(s"PType $displayName can not be coerced to ${other.displayName}!")
+        case itt: IsTextType => {
           val wiki = get(elem)
           itt(wiki.strip)
         }
@@ -387,37 +491,51 @@ class QLEcot(e:Ecology) extends QuerkiEcot(e) with QL with QLInternals with QLTe
     def rawString(elem: ElemValue): String = {
       elem.elem match {
         case w: Wikitext => w.plaintext
-        case _ => throw new Exception(s"ParsedTextType.rawString() got invalid value $elem!")
+        case _           => throw new Exception(s"ParsedTextType.rawString() got invalid value $elem!")
       }
     }
+
     def apply(raw: String): ElemValue = {
       ElemValue(Wikitext(raw), this)
     }
   }
-  
-  lazy val ClosureType = new SystemType[QLClosure](UnknownOID,
+
+  lazy val ClosureType = new SystemType[QLClosure](
+    UnknownOID,
     toProps(
       setName("_QL Closure"),
-      setInternal)) with SimplePTypeBuilder[QLClosure]
-  {
-    def doDeserialize(v:String)(implicit state:SpaceState) = ???
-    def doSerialize(v:QLClosure)(implicit state:SpaceState) = ???
-    def doWikify(context:QLContext)(v:QLClosure, displayOpt:Option[Wikitext] = None, lexicalThing:Option[PropertyBundle] = None) = ???
-    def doDefault(implicit state:SpaceState) = ???
+      setInternal
+    )
+  ) with SimplePTypeBuilder[QLClosure] {
+    def doDeserialize(v: String)(implicit state: SpaceState) = ???
+    def doSerialize(v: QLClosure)(implicit state: SpaceState) = ???
+
+    def doWikify(
+      context: QLContext
+    )(
+      v: QLClosure,
+      displayOpt: Option[Wikitext] = None,
+      lexicalThing: Option[PropertyBundle] = None
+    ) = ???
+    def doDefault(implicit state: SpaceState) = ???
     // This is a transient PType, so we don't care:
-    def doComputeMemSize(v:QLClosure):Int = 0
+    def doComputeMemSize(v: QLClosure): Int = 0
   }
-  
-  /***********************************************
+
+  /**
+   * *********************************************
    * FUNCTIONS
-   ***********************************************/
-  
-  lazy val SelfMethod = new InternalMethod(SelfMethodOID,
+   * *********************************************
+   */
+
+  lazy val SelfMethod = new InternalMethod(
+    SelfMethodOID,
     toProps(
       setName("_self"),
       Categories(QLTag),
       Summary("Get a Link to this Thing"),
-      Details("""*thing*._self simply produces *thing*.
+      Details(
+        """*thing*._self simply produces *thing*.
           |
           |This seems silly, but it is useful for overriding the usual \_apply behavior. In particular,
           |*property*.\_self is the way to get a link to the property itself, instead of fetching the value
@@ -434,17 +552,21 @@ class QLEcot(e:Ecology) extends QuerkiEcot(e) with QL with QLInternals with QLTe
           |something else. If you're trying to fetch "everything that points to this" (one of the more common
           |cases), check out [[_refs._self]], which does exactly this. Or, if you are in a QL expression and are
           |looking for a way to say "this Thing that I'm looking at here", you can usually get that as
-          |`$_context`. (Which is technically "the value passed into this QL expression at the beginning".)""".stripMargin)))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+          |`$_context`. (Which is technically "the value passed into this QL expression at the beginning".)""".stripMargin
+      )
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       inv.definingContext match {
         case Some(context) => Future.successful(context.value)
-        case _ => Future.successful(WarningValue("QL.self.notDotted")) 
+        case _             => Future.successful(WarningValue("QL.self.notDotted"))
       }
     }
   }
-  
-  lazy val IsBoundFunction = new InternalMethod(IsBoundFunctionOID,
+
+  lazy val IsBoundFunction = new InternalMethod(
+    IsBoundFunctionOID,
     toProps(
       setName("_isBound"),
       Categories(QLTag),
@@ -456,9 +578,11 @@ class QLEcot(e:Ecology) extends QuerkiEcot(e) with QL with QLInternals with QLTe
         ),
         opts = Seq.empty,
         returns = (YesNoType, "True iff the given name is currently bound, false otherwise.")
-      )))
-  {
-    override def qlApply(inv:Invocation):QFut = {
+      )
+    )
+  ) {
+
+    override def qlApply(inv: Invocation): QFut = {
       lazy val errOpt = Some(new PublicException("QL.isBound.notABinding"))
       for {
         param <- inv.rawRequiredParam("name")
@@ -467,7 +591,7 @@ class QLEcot(e:Ecology) extends QuerkiEcot(e) with QL with QLInternals with QLTe
         QLCall(binding, _, _, _) = stage
         QLBinding(name) = binding
         parser <- inv.opt(inv.context.parser)
-        scopes <- inv.opt(inv.context.scopes.get(parser))
+        scopes <- inv.opt(inv.context.scopes.get(parser.processor))
         answer = {
           // Look in the lexical scope first...
           scopes.lookup(name).orElse {
@@ -475,43 +599,48 @@ class QLEcot(e:Ecology) extends QuerkiEcot(e) with QL with QLInternals with QLTe
             inv.context.requestOpt.flatMap(_.parsedParams.get(name))
           }.isDefined
         }
-      }
-        yield ExactlyOne(YesNoType(answer))
+      } yield ExactlyOne(YesNoType(answer))
     }
   }
-  
-  lazy val CodeMethod = new InternalMethod(CodeMethodOID,
+
+  lazy val CodeMethod = new InternalMethod(
+    CodeMethodOID,
     toProps(
       setName("_code"),
       Categories(QLTag),
       Summary("Display a block of QL code"),
       Details("""_code() displays the raw code of a value or property, pretty flexibly.
-          |
-          |You can give it as "TEXT -> _code" to display the TEXT -- however, note that the TEXT will be processed as normal
-          |in this case. If you want to show some raw code, unprocessed, do it as "_code(TEXT)" instead.
-          |
-          |You can give a property as a parameter -- "_code(PROP)" -- and it will display the value of the property on this Thing.
-          |
-          |Or you can give a property on some other Thing -- "_code(THING.PROP)" -- to display the value of the property on that Thing.
-          |
-          |If you have a parameter, and it doesn't work as either PROP or THING.PROP, then it will display the parameter literally.
-          |
-          |The results are displayed in an inset block, in monospaced type, so that it looks "codish".
-          |
-          |_code is, frankly, a bit persnickety at this point, and not always easy to use for complicated examples. It should be
-          |considered a work in progress.""".stripMargin)))
-  {
-    def encodeString(str:String):QFut = {
+                |
+                |You can give it as "TEXT -> _code" to display the TEXT -- however, note that the TEXT will be processed as normal
+                |in this case. If you want to show some raw code, unprocessed, do it as "_code(TEXT)" instead.
+                |
+                |You can give a property as a parameter -- "_code(PROP)" -- and it will display the value of the property on this Thing.
+                |
+                |Or you can give a property on some other Thing -- "_code(THING.PROP)" -- to display the value of the property on that Thing.
+                |
+                |If you have a parameter, and it doesn't work as either PROP or THING.PROP, then it will display the parameter literally.
+                |
+                |The results are displayed in an inset block, in monospaced type, so that it looks "codish".
+                |
+                |_code is, frankly, a bit persnickety at this point, and not always easy to use for complicated examples. It should be
+                |considered a work in progress.""".stripMargin)
+    )
+  ) {
+
+    def encodeString(str: String): QFut = {
       val escaped = scala.xml.Utility.escape(str)
-      Future.successful(HtmlUI.HtmlValue(QHtml("<pre>" + escaped + "</pre>")))    
+      Future.successful(HtmlUI.HtmlValue(QHtml("<pre>" + escaped + "</pre>")))
     }
-    
-    def encode(propVal:QValue, pType:PType[_]):QFut = {
+
+    def encode(
+      propVal: QValue,
+      pType: PType[_]
+    ): QFut = {
       if (propVal.isEmpty)
         WarningFut("_code got an empty input")
       else {
         pType match {
-          case codeType:CodeType => {
+          case codeType: CodeType => {
             val str = codeType.code(propVal.first)
             encodeString(str)
           }
@@ -522,17 +651,22 @@ class QLEcot(e:Ecology) extends QuerkiEcot(e) with QL with QLInternals with QLTe
         }
       }
     }
-    
-    def encodeThingAndProp(thing:Thing, prop:Thing)(implicit space:SpaceState):Option[QFut] = {
+
+    def encodeThingAndProp(
+      thing: Thing,
+      prop: Thing
+    )(implicit
+      space: SpaceState
+    ): Option[QFut] = {
       val propAndValOpt = thing.getPropOpt(prop.id)
-      propAndValOpt.map { propAndVal => 
+      propAndValOpt.map { propAndVal =>
         encode(propAndVal.v, propAndVal.prop.pType)
       }
     }
-    
+
     // TODO: this is horrible. Surely we can turn this into something cleaner with better use of the functional
     // tools in the Scala toolbelt.
-    override def qlApply(inv:Invocation):QFut = {
+    override def qlApply(inv: Invocation): QFut = {
       val partialContext = inv.preferDefiningContext.context
       implicit val space = partialContext.state
       inv.paramsOpt match {
@@ -545,19 +679,18 @@ class QLEcot(e:Ecology) extends QuerkiEcot(e) with QL with QLInternals with QLTe
           val stage = param.exp.phrases.head.ops.head
           stage match {
             case QLTextStage(contents, _) => encodeString(contents.reconstructString)
-            case QLNumber(num) => encodeString(stage.reconstructString)
-            case lit:QLListLiteral => encodeString(lit.reconstructString) 
+            case QLNumber(num)            => encodeString(stage.reconstructString)
+            case lit: QLListLiteral       => encodeString(lit.reconstructString)
             case QLCall(name, methodNameOpt, _, _) => {
               val thingName = name.name
               methodNameOpt match {
                 case Some(methodName) => {
-                  val resultOpt = for (
-                    thing <- space.anythingByName(thingName);
-                    propThing <- space.anythingByName(methodName.name);
+                  val resultOpt = for {
+                    thing <- space.anythingByName(thingName)
+                    propThing <- space.anythingByName(methodName.name)
                     encoded <- encodeThingAndProp(thing, propThing)
-                  )
-                    yield encoded
-                    
+                  } yield encoded
+
                   resultOpt.getOrElse(encodeString(param.reconstructString))
                 }
                 case None => {
@@ -566,16 +699,16 @@ class QLEcot(e:Ecology) extends QuerkiEcot(e) with QL with QLInternals with QLTe
                     case Some(propThing) => {
                       for {
                         thing <- inv.contextAllThings
-                        res <- inv.fut(encodeThingAndProp(thing, propThing).getOrElse(encodeString(param.reconstructString)))
-                      }
-                        yield res
+                        res <-
+                          inv.fut(encodeThingAndProp(thing, propThing).getOrElse(encodeString(param.reconstructString)))
+                      } yield res
                     }
                     case None => encodeString(param.reconstructString)
                   }
                 }
               }
             }
-            case exp:QLExpStage => encodeString(exp.reconstructString)
+            case exp: QLExpStage           => encodeString(exp.reconstructString)
             case block: QLTextBlockLiteral => encodeString(block.reconstructString)
           }
         }

--- a/querki/scalajvm/app/querki/ql/QLEcot.scala
+++ b/querki/scalajvm/app/querki/ql/QLEcot.scala
@@ -169,6 +169,17 @@ class QLEcot(e: Ecology)
     parserProcessMethodProfiler.profile { parser.processMethodToWikitext }
   }
 
+  def processExp(
+    ci: QLContext,
+    exp: QLExp,
+    invOpt: Option[Invocation] = None,
+    parserOpt: Option[QLParser] = None,
+    initialBindings: Option[Map[String, QValue]] = None
+  ): Future[QLContext] = {
+    val processor = parserCreateProfiler.profile { new QLProcessor(ci, invOpt, parserOpt, initialBindings) }
+    parserProcessMethodProfiler.profile { processor.processExp(exp, ci) }
+  }
+
   def parseMethod(input: String): Option[QLPhrase] = {
     // Since we're just parsing, we shouldn't need a context:
     val parser = parserCreateProfiler.profile { new QLParser(QLText(input), EmptyContext(ecology)) }

--- a/querki/scalajvm/app/querki/ql/QLParser.scala
+++ b/querki/scalajvm/app/querki/ql/QLParser.scala
@@ -303,7 +303,7 @@ class QLParser(
     exp: QLExp,
     context: QLContext
   ): Future[QLContext] = {
-    processor.withScope(context, processExp(exp, _))
+    processor.processExpAsScope(exp, context)
   }
 
 }

--- a/querki/scalajvm/app/querki/ql/QLParser.scala
+++ b/querki/scalajvm/app/querki/ql/QLParser.scala
@@ -14,88 +14,56 @@ import querki.html.QHtml
 import querki.util.{DebugRenderable, UnexpectedPublicException}
 import querki.values._
 
-/**
- * This is created by and obtained from the QLEcot:
- */
-private [ql] class QLProfilers(implicit val ecology:Ecology) extends EcologyMember {
-  lazy val Profiler = interface[querki.tools.Profiler]  
-  
-  lazy val parse = Profiler.createHandle("QLParser.parse")
-  lazy val processMethod = Profiler.createHandle("QLParser.processMethod")
-  lazy val processCall = Profiler.createHandle("QLParser.processCall")
-  lazy val processTextStage = Profiler.createHandle("QLParser.processTextStage")
-  lazy val processNumber = Profiler.createHandle("QLParser.processNumber")
-  lazy val processCallDetail = Profiler.createHandle("QLParser.call")
-  lazy val processThing = Profiler.createHandle("QLParser.processThing")
-  lazy val wikify = Profiler.createHandle("QLParser.wikify")
-}
-
 sealed trait QLParseResult[T <: QLParseResultVal]
-case class QLParseSuccess[T <: QLParseResultVal](result:T) extends QLParseResult[T]
-case class QLParseFailure[T <: QLParseResultVal](msgFut:Future[Wikitext]) extends QLParseResult[T]
-
-case class QLScope(bindings:Map[String, QValue] = Map.empty) {
-  def bind(pair:(String, QValue)) = copy(bindings = bindings + pair)
-  def lookup(name:String) = bindings.get(name)
-}
-case class QLScopes(scopes:List[QLScope] = List.empty) {
-  // Add the specified binding to the current scope:
-  def bind(pair:(String, QValue)) = {
-    val newScopes = (scopes.head.bind(pair)) :: scopes.tail
-    copy(scopes = newScopes)
-  }
-  
-  def lookup(name:String):Option[QValue] = {
-    (Option.empty[QValue] /: scopes) { (result, scope) =>
-      result match {
-        case Some(r) => result
-        case None => scope.lookup(name)
-      }
-    }
-  }
-  
-  def push = copy(scopes = QLScope() :: scopes)
-  def pop = copy(scopes = scopes.tail)
-}
+case class QLParseSuccess[T <: QLParseResultVal](result: T) extends QLParseResult[T]
+case class QLParseFailure[T <: QLParseResultVal](msgFut: Future[Wikitext]) extends QLParseResult[T]
 
 class QLParser(
-    val input:QLText, ci:QLContext, invOpt:Option[Invocation] = None, 
-    val lexicalThing:Option[PropertyBundle] = None, val lexicalProp:Option[AnyProp] = None,
-    val initialBindings:Option[Map[String, QValue]] = None)
-  (implicit val ecology:Ecology) 
-  extends RegexParsers with EcologyMember 
-{
-  
+  val input: QLText,
+  ci: QLContext,
+  invOpt: Option[Invocation] = None,
+  val lexicalThing: Option[PropertyBundle] = None,
+  val lexicalProp: Option[AnyProp] = None,
+  val initialBindings: Option[Map[String, QValue]] = None
+)(implicit
+  val ecology: Ecology
+) extends RegexParsers
+     with EcologyMember {
+
   lazy val initialScopes = initialBindings match {
     case Some(bindings) => QLScopes(List(QLScope(bindings)))
-    case None => QLScopes()
+    case None           => QLScopes()
   }
+
   // Add the parser to the context, so that methods can call back into it. Note that we are treating this as essentially
-  // a modification, rather than another level of depth. We also provide an initial scope for this parser:
-  val initialContext = ci.copy(parser = Some(this), scopes = ci.scopes + (this -> initialScopes.push))(ci.state, ecology)
-  
+  // a modification, rather than another level of depth.
+  val parserContext =
+    ci.copy(parser = Some(this))(ci.state, ecology)
+
   /**
    * Create a new parser, that includes the given bindings. This is intended mainly for "meta" functions,
    * which want to fix some bindings and then call processExp().
    */
-  def withBindings(bindings: Map[String, QValue]):QLParser = {
+  def withBindings(bindings: Map[String, QValue]): QLParser = {
     new QLParser(input, ci, invOpt, lexicalThing, lexicalProp, Some(initialBindings.getOrElse(Map.empty) ++ bindings))
   }
-  
+
   val paramsOpt = invOpt.flatMap(_.paramsOpt)
-  
+
   lazy val Basic = interface[querki.basic.Basic]
   lazy val Core = interface[querki.core.Core]
   lazy val QL = interface[querki.ql.QL]
   lazy val QLInternals = interface[QLInternals]
   lazy val Tags = interface[querki.tags.Tags]
-  
+
   lazy val qlProfilers = QLInternals.qlProfilers
-  
+
   lazy val ExactlyOne = Core.ExactlyOne
   lazy val PlainTextType = Basic.PlainTextType
-  
+
   def WarningValue = QL.WarningValue _
+
+  lazy val processor = new QLProcessor(parserContext, invOpt, Some(this), initialBindings)
 
   // *****************************************
   //
@@ -103,12 +71,18 @@ class QLParser(
   //
   // Crude but useful debugging of the process tree. Could stand to be beefed up when I have time
   //
-  
+
   // A unique ID that we attach to each Stage, for understanding what's going on:
   val stageId = new java.util.concurrent.atomic.AtomicInteger()
   // Turn this to true to produce voluminous output from the QL processing pipeline
   val doLogContext = Config.getBoolean("querki.test.logContexts", false)
-  def logStage(stage:QLStage, context:QLContext)(processor: => Future[QLContext]):Future[QLContext] = {
+
+  def logStage(
+    stage: QLStage,
+    context: QLContext
+  )(
+    processor: => Future[QLContext]
+  ): Future[QLContext] = {
     if (doLogContext) {
       try {
         val sid = stageId.getAndIncrement
@@ -116,24 +90,27 @@ class QLParser(
         QLog.info(s"$indent$sid: [[${stage.reconstructString}]] on ${context.debugRender}")
         val result = processor
         result.onComplete {
-          case scala.util.Success(result) => 
+          case scala.util.Success(result) =>
             QLog.info(s"$indent$sid = ${result.debugRender}")
           case scala.util.Failure(ex) =>
             QLog.error(s"$indent$sid returned Failure!", ex)
         }
         result
       } catch {
-        case th:Throwable => { 
-          QLog.error(s"Exception while processing stage ${stage.reconstructString} with context ${context.debugRender}", th)
+        case th: Throwable => {
+          QLog.error(
+            s"Exception while processing stage ${stage.reconstructString} with context ${context.debugRender}",
+            th
+          )
           throw th
         }
       }
     } else
       processor
   }
-  
+
   // *****************************************
-  
+
   final val name = querki.core.nameRegex
   // These two regexes are used in the unQLText production. Yes, they *could* be combined into one
   // expression, and originally were. They were split because having them together apparently does
@@ -148,659 +125,240 @@ class QLParser(
 
   // Comments are defined in here. Note that a comment is defined as everything from "//"
   // to the end of the line *or* a "]]", so that we can put them at the end of an expression.
-  def qlSpace:Parser[QLSpace] = "(\\s*(//([^\n\\]]|(\\]?!\\]))*)?\\s*)*".r ^^ { QLSpace(_) }
-  
-  def unQLText:Parser[UnQLText] = (unQLTextRegex | 
+  def qlSpace: Parser[QLSpace] = "(\\s*(//([^\n\\]]|(\\]?!\\]))*)?\\s*)*".r ^^ { QLSpace(_) }
+
+  def unQLText: Parser[UnQLText] =
+    (unQLTextRegex |
       // You can use backslash to escape the "special" QL syntax delimiters:
       "\\\\".r ~> ("\"\"".r | "\\[\\[".r | "\\]\\]".r | "____".r | "__".r) |
       // If we haven't use the backslash for that, then just eat it as a normal character:
-      "\\\\".r | 
+      "\\\\".r |
       partialDelimiterRegex) ^^ { UnQLText(_) }
   def qlNumber[QLNumber] = "\\s*".r ~> "\\-?\\d+".r ^^ { intStr => QLNumber(java.lang.Long.parseLong(intStr)) }
   def qlSafeName[QLSafeName] = name ^^ { QLSafeName(_) }
   def qlDisplayName[QLDisplayName] = "`" ~> "[^`]*".r <~ "`" ^^ { QLDisplayName(_) }
   def qlThingId[QLThingId] = "." ~> "\\w*".r ^^ { oid => QLThingId("." + oid) }
-  def qlName:Parser[QLName] = qlDef | qlBindingDef | qlBinding | qlThingId | qlSafeName | qlDisplayName
-  def qlOp:Parser[String] = ("&" | "|")
-  def qlUnOp:Parser[String] = ("!")
-  def qlCall:Parser[QLCall] = opt("\\*\\s*".r) ~ qlName ~ opt("." ~> qlName) ~ opt(qlParamList) ^^ { 
-    case collFlag ~ n ~ optMethod ~ optParams => QLCall(n, optMethod, optParams, collFlag) }
+  def qlName: Parser[QLName] = qlDef | qlBindingDef | qlBinding | qlThingId | qlSafeName | qlDisplayName
+  def qlOp: Parser[String] = ("&" | "|")
+  def qlUnOp: Parser[String] = ("!")
+
+  def qlCall: Parser[QLCall] = opt("\\*\\s*".r) ~ qlName ~ opt("." ~> qlName) ~ opt(qlParamList) ^^ {
+    case collFlag ~ n ~ optMethod ~ optParams => QLCall(n, optMethod, optParams, collFlag)
+  }
+
   // Note that the failure() here only works because we specifically disallow "]]" in a Text!
-  def qlTextStage:Parser[QLTextStage] = (opt("\\*\\s*".r) <~ "\"\"") ~ qlText <~ ("\"\"" | failure("Reached the end of the QL expression, but missing the closing \"\" for a Text expression in it") ) ^^ {
-    case collFlag ~ text => QLTextStage(text, collFlag) }
-  def qlExpStage:Parser[QLStage] = "(" ~> qlExp <~ ")" ^^ { QLExpStage(_) }
-  def qlDef:Parser[QLBindingDef] = "\\s*_def\\s+\\$".r ~> name ~ opt("(" ~> rep1sep("$" ~> name, "\\s*,\\s*".r) <~ ")") ~ ("\\s+=\\s+".r ~> qlPhrase) ^^ {
+  def qlTextStage: Parser[QLTextStage] = (opt("\\*\\s*".r) <~ "\"\"") ~ qlText <~ ("\"\"" | failure(
+    "Reached the end of the QL expression, but missing the closing \"\" for a Text expression in it"
+  )) ^^ {
+    case collFlag ~ text => QLTextStage(text, collFlag)
+  }
+  def qlExpStage: Parser[QLStage] = "(" ~> qlExp <~ ")" ^^ { QLExpStage(_) }
+
+  def qlDef: Parser[QLBindingDef] = "\\s*_def\\s+\\$".r ~> name ~ opt(
+    "(" ~> rep1sep("$" ~> name, "\\s*,\\s*".r) <~ ")"
+  ) ~ ("\\s+=\\s+".r ~> qlPhrase) ^^ {
     case name ~ params ~ phrase => QLBindingDef(name, Some(phrase), params)
   }
+
   def qlTextBlockLiteral: Parser[QLTextBlockLiteral] = "\\s*".r ~ "```" ~> "(?s)(?:(?!```).)*".r <~ "```" ^^ {
-    block => QLTextBlockLiteral(block) 
+    block => QLTextBlockLiteral(block)
   }
-  def qlBinding:Parser[QLBinding] = "\\s*\\$".r ~> name ^^ { 
-    case name => QLBinding(name) 
+
+  def qlBinding: Parser[QLBinding] = "\\s*\\$".r ~> name ^^ {
+    case name => QLBinding(name)
   }
-  def qlBindingDef:Parser[QLBindingDef] = "\\s*\\+\\$".r ~> name ~ opt("\\(\\s*".r ~> (repsep(qlParam, "\\s*,\\s*".r) <~ "\\s*\\)".r)) ^^ { 
-    case name ~ params => QLBindingDef(name, None, None) 
-  }
-  def qlBasicStage:Parser[QLStage] = qlTextBlockLiteral | qlNumber | qlCall | qlTextStage | qlList | qlExpStage
-  def qlUnOpStage:Parser[QLStage] = opt(qlUnOp <~ "\\s*".r) ~ qlBasicStage ^^ {
+
+  def qlBindingDef: Parser[QLBindingDef] =
+    "\\s*\\+\\$".r ~> name ~ opt("\\(\\s*".r ~> (repsep(qlParam, "\\s*,\\s*".r) <~ "\\s*\\)".r)) ^^ {
+      case name ~ params => QLBindingDef(name, None, None)
+    }
+  def qlBasicStage: Parser[QLStage] = qlTextBlockLiteral | qlNumber | qlCall | qlTextStage | qlList | qlExpStage
+
+  def qlUnOpStage: Parser[QLStage] = opt(qlUnOp <~ "\\s*".r) ~ qlBasicStage ^^ {
     case unop ~ guts => {
       unop match {
         case Some(op) => {
           val funcName = op match {
             case "!" => "_not"
-            case _ => throw new Exception(s"qlUnaryOperation got unknown operator $op")
+            case _   => throw new Exception(s"qlUnaryOperation got unknown operator $op")
           }
-          QLCall(QLSafeName(funcName), None,
-              Some(Seq(QLParam(None, QLExp(Seq(QLPhrase(Seq(guts))))))),
-              None)
+          QLCall(QLSafeName(funcName), None, Some(Seq(QLParam(None, QLExp(Seq(QLPhrase(Seq(guts))))))), None)
         }
         case None => guts
       }
     }
   }
-  def qlStage:Parser[QLStage] = qlUnOpStage ~ opt("\\s+".r ~> qlOp ~ ("\\s+".r ~> qlUnOpStage)) ^^ {
+
+  def qlStage: Parser[QLStage] = qlUnOpStage ~ opt("\\s+".r ~> qlOp ~ ("\\s+".r ~> qlUnOpStage)) ^^ {
     case left ~ operation => {
       operation match {
         case Some(op ~ right) => {
           val funcName = op match {
             case "&" => "_and"
             case "|" => "_or"
-            case _ => throw new Exception(s"qlBinaryOperation got unknown operator $op")
+            case _   => throw new Exception(s"qlBinaryOperation got unknown operator $op")
           }
-          QLCall(QLSafeName(funcName), None, 
-              Some(Seq(QLParam(None, QLExp(Seq(QLPhrase(Seq(left))))),
-                       QLParam(None, QLExp(Seq(QLPhrase(Seq(right))))))),
-              None)
+          QLCall(
+            QLSafeName(funcName),
+            None,
+            Some(Seq(QLParam(None, QLExp(Seq(QLPhrase(Seq(left))))), QLParam(None, QLExp(Seq(QLPhrase(Seq(right))))))),
+            None
+          )
         }
         case None => left
       }
     }
   }
-  def qlParamList:Parser[Seq[QLParam]] = qlEmptyParamList | qlRealParamList
-  def qlEmptyParamList:Parser[Seq[QLParam]] = "\\(\\s*\\)".r ^^ { case _ => Seq.empty }
-  def qlRealParamList:Parser[Seq[QLParam]] = "\\(\\s*".r ~> (rep1sep(qlParam, "\\s*,\\s*".r) <~ "\\s*\\)".r)
-  def qlParam:Parser[QLParam] = opt(name <~ "\\s*=\\s*".r) ~ opt("~!") ~ qlExp ^^ { 
-    case nameOpt ~ immediateOpt ~ exp => QLParam(nameOpt, exp, immediateOpt.isDefined) 
+  def qlParamList: Parser[Seq[QLParam]] = qlEmptyParamList | qlRealParamList
+  def qlEmptyParamList: Parser[Seq[QLParam]] = "\\(\\s*\\)".r ^^ { case _ => Seq.empty }
+  def qlRealParamList: Parser[Seq[QLParam]] = "\\(\\s*".r ~> (rep1sep(qlParam, "\\s*,\\s*".r) <~ "\\s*\\)".r)
+
+  def qlParam: Parser[QLParam] = opt(name <~ "\\s*=\\s*".r) ~ opt("~!") ~ qlExp ^^ {
+    case nameOpt ~ immediateOpt ~ exp => QLParam(nameOpt, exp, immediateOpt.isDefined)
   }
-  def qlPhrase:Parser[QLPhrase] = rep1sep(qlStage, qlSpace ~ "->".r ~ qlSpace) ^^ { QLPhrase(_) }
+  def qlPhrase: Parser[QLPhrase] = rep1sep(qlStage, qlSpace ~ "->".r ~ qlSpace) ^^ { QLPhrase(_) }
+
   // Phrases are separated either by qlSpace (including comments) or semicolons
-  def qlExp:Parser[QLExp] = opt(qlSpace) ~> repsep(qlPhrase, opt(qlSpace) ~ opt(";") ~ qlSpace) <~ opt(qlSpace) ^^ { QLExp(_) }
-  def qlLink:Parser[QLLink] = qlText ^^ { QLLink(_) }
-  def qlText:Parser[ParsedQLText] = rep(unQLText | "[[" ~> qlExp <~ "]]" | "__" ~> qlLink <~ ("__" | failure("Underscores must always be in pairs or sets of four"))) ^^ { 
-    ParsedQLText(_) }
-  def qlList:Parser[QLCall] = "<" ~> rep1sep(qlExp, qlSpace ~ "," ~ qlSpace) <~ qlSpace ~ ">" ^^ 
+  def qlExp: Parser[QLExp] = opt(qlSpace) ~> repsep(qlPhrase, opt(qlSpace) ~ opt(";") ~ qlSpace) <~ opt(qlSpace) ^^ {
+    QLExp(_)
+  }
+  def qlLink: Parser[QLLink] = qlText ^^ { QLLink(_) }
+
+  def qlText: Parser[ParsedQLText] = rep(unQLText | "[[" ~> qlExp <~ "]]" | "__" ~> qlLink <~ ("__" | failure(
+    "Underscores must always be in pairs or sets of four"
+  ))) ^^ {
+    ParsedQLText(_)
+  }
+
+  def qlList: Parser[QLCall] = "<" ~> rep1sep(qlExp, qlSpace ~ "," ~ qlSpace) <~ qlSpace ~ ">" ^^
     // We've found that _concat already works well for this, so simply desugar to that:
     // { QLListLiteral(_) }
     { params => QLCall(QLSafeName("_concat"), None, Some(params.map(param => QLParam(None, param, false))), None) }
-  
-  /**
-   * Note that the output here is nominally a new Context, but the underlying type is
-   * ParsedTextType. So far, you can't *do* anything with that afterwards other than
-   * render it, which just returns the already-computed Wikitext.
-   */
-  private def processTextStage(text:QLTextStage, context:QLContext):Future[QLContext] = {
-    val ct = context.value.cType
-    // For each element of the incoming context, recurse in and process the embedded Text
-    // in that context. Iff the context is empty, though, just produce an empty result *unless*
-    // they have asked for the full collection.
-    val transformedFuts =
-      if (context.isEmpty && text.collFlag.isEmpty)
-        Iterable.empty
-      else
-        context.map { elemContext =>
-          processParseTree(text.contents, elemContext).map(QL.ParsedTextType(_))
-        }
-    
-    val transformedFut = Future.sequence(transformedFuts)
-    
-    // TBD: the asInstanceOf here is surprising -- I would have expected transformed to come out
-    // as the right type simply by type signature. Can we get rid of it?
-    transformedFut.map(transformed => context.next(ct.makePropValue(transformed.asInstanceOf[ct.implType], QL.ParsedTextType)))
-  }
-  
-  private def processCall(call:QLCall, context:QLContext, isParam:Boolean):Future[QLContext] = {
-    
-    def lookupMethod():Future[Option[Thing]] = {
-      call.methodName match {
-        case Some(qlName) => {
-          qlName match {
-            case binding:QLBinding => {
-              processBinding(binding, context, isParam, call) map { resolvedBinding =>
-                if (resolvedBinding.value.matchesType(Core.LinkType)) {
-                  for {
-                    // TODO: for now, we don't cope with multiple resolved results here. I'm not even
-                    // sure why you'd ever want that:
-                    oid <- resolvedBinding.value.rawList(Core.LinkType).headOption
-                    thing <- context.state.anything(oid)
-                  }
-                    yield thing
-                } else {
-                  None
-                }                
-              }
-            }
-            case tid:QLThingId => Future.successful(context.state.anything(ThingId(tid.name)))
-            case _ => Future.successful(context.state.anythingByName(qlName.name))
-          }
-        }
-        case None => Future.successful(None)
-      }
-    }
-    
-    def processThing(t:Thing, context:QLContext):Future[QLContext] = qlProfilers.processThing.profile {
-      // If there are parameters to the call, they are a collection of phrases. If any are marked immediate
-      // (prefixed with "!"), they gets processed *now*, rather than meta-programmed later:
-      val paramsFOpt:Option[Seq[Future[QLParam]]] = call.params map { params =>
-        params.map { param =>
-          if (param.immediate) {
-            processExp(param.exp, context).map { processed =>
-              param.copy(resolved = Some(processed))
-            }
-          } else
-            Future.successful(param)
-        }
-      }
-      val paramsFut:Future[Option[Seq[QLParam]]] = paramsFOpt match {
-        case Some(paramsSeq) => {
-          Future.sequence(paramsSeq).map(Some(_))
-        }
-        case None => Future.successful(None)
-      }
-      paramsFut.flatMap { params =>
-        lookupMethod().flatMap {
-          case Some(method) => {
-            val definingContext = context.next(Core.ExactlyOne(Core.LinkType(t.id)))
-            qlProfilers.processCallDetail.profileAs(" " + call.name.name) {
-              method.qlApplyTop(InvocationImpl(t, method, context.withCall(call, method), Some(definingContext), params), method)
-            }
-          }
-          case None => {
-            qlProfilers.processCallDetail.profileAs(" " + call.name.name) {
-              val inv = InvocationImpl(t, t, context.withCall(call, t), None, params)
-              t.qlApplyTop(inv, t)
-            }
-          }
-        }
-      }
-    }
-    
-    call.name match {
-      case binding:QLBinding => { 
-        processBinding(binding, context, isParam, call).flatMap { resolvedBinding =>  
-          if (resolvedBinding.value.matchesType(Core.LinkType)) {
-            val resultFuts = for {
-              oid <- resolvedBinding.value.rawList(Core.LinkType)
-              thing <- context.state.anything(oid)
-              fut = processThing(thing, context)
-            }
-              yield fut
-              
-            val resultFut = Future.sequence(resultFuts)
-            resultFut.map(results => resolvedBinding.concat(results))
-          } else {
-            Future.successful(resolvedBinding)
-          }
-        }
-      }
-      case bindingDef:QLBindingDef => {
-        processBindingDef(bindingDef, context)
-      }
-      case tid:QLThingId => {
-        // Note: this is structured to fix QI.7w4g8tv: cope if the tid *looks* like an OID, but
-        // doesn't parse right:
-        ThingId.parseOpt(tid.name).map { thingId =>
-          context.state.anything(thingId) match {
-            case Some(t) => processThing(t, context)
-            case None => Future.failed(new PublicException("QL.unknownThingId", tid.reconstructString))
-          }
-        }.getOrElse(Future.failed(new PublicException("QL.unknownThingId", tid.reconstructString)))
-      }
-      case _ => {
-        // Looking up a Thing by name, which is the most common situation:
-        context.state.anythingByName(call.name.name) match {
-          // Normal case: we found this Thing by name:
-          case Some(t) => processThing(t, context)
-          // We *didn't* find the Thing...
-          case None => {
-            // Note: before QI.9v5kelv, we distinguished depending on whether call.name.name was a known Tag
-            // (in which case we returned UnknownNameType) or not (in which case we raised the
-            // "QL.unknownName" error). We now only do the former -- the latter has simply proven to be
-            // annoying without much benefit. (We also allowed backtick-delimited names even if they were
-            // unknown, which was *way* too subtle.)
-            Future.successful(context.next(Core.ExactlyOne(QL.UnknownNameType(call.name.name))))
-          }
-        }
-      }
-    }
-  }
-  
-  def warningFut(context:QLContext, msg:String):Future[QLContext] = {
-    Future.successful(context.next(WarningValue(msg)))
-  }
-  
-  private def processBindingDef(binding:QLBindingDef, context:QLContext):Future[QLContext] = {
-    context.scopes.get(this).map { scopes =>
-      val boundOpt = scopes.lookup(binding.name)
-      if (boundOpt.isDefined) {
-        warningFut(context, s"Attempting to reassign ${"$" + binding.name} -- you may only say ${"+$" + binding.name} once")
-      } else {
-        // Okay -- we are legally attempting to bind this name to the received value:
-        val newScopes:QLScopes =
-          binding.func match {
-            case Some(func) => {
-              // We're binding a local function, so we ignore the context and instead just use that:
-              val closure = QLClosure(QLExp(Seq(func)), binding.params)
-              val v = ExactlyOne(QL.ClosureType(closure))
-              scopes.bind((binding.name -> v))
-            } 
-            // Ordinary binding, so we just bind the current context to this name:
-            case _ => scopes.bind((binding.name -> context.value))
-          }
-        val newContext = context.withScopes(this, newScopes)
-        fut(newContext)
-      }
-    }.getOrElse {
-      QLog.error(s"Failed to find the scope for binding $binding!")
-      warningFut(context, s"Internal error while trying to parse!") 
-    }
-  }
-  
-  private def processNormalBinding(binding:QLBinding, context:QLContext, isParam:Boolean, resolvingParser:QLParser, call:QLCall):Future[QLContext] = {
-    val scopes = context.scopes(this)
-    val boundOpt = scopes.lookup(binding.name)
-    boundOpt match {
-      // Fetching an already-bound value
-      case Some(bound) => {
-        if (bound.pType == QL.ClosureType) {
-          // We're invoking a local function, so process that:
-          val closure = bound.firstAs(QL.ClosureType).get
-          closure.params match {
-            case Some(formals) => {
-              // There are formal parameters for the function, so we need to bind those to the actuals:
-              val actuals = call.params.getOrElse(throw new Exception(s"Locally-defined function ${binding.name} requires parameters."))
-              // The number of params must match exactly, since we don't have optional params yet:
-              if (formals.length != actuals.length)
-                throw new Exception(s"Locally-defined function ${binding.name} requires ${formals.length} parameters.")
-              val actualVs = actuals.map { actual => ExactlyOne(QL.ClosureType(QLClosure(actual.exp, None))) }
-              val pairs = formals zip actualVs
-              withScope(context, { scopedContext =>
-                val newScopes = (scopedContext.scopes(this) /: pairs) { (scopes, pair) =>
-                  scopes.bind(pair)
-                }
-                processExp(closure.exp, scopedContext.withScopes(this, newScopes))
-              })
-            }
-            // An ordinary closure value, which just gets evaluated with the context:
-            case None => processExp(closure.exp, context)
-          }
-        } else {
-          // Normal value -- just stick it in:
-          fut(context.next(bound))
-        }
-      }
-      case None => {
-        // It's not bound lexically. Does it exist in the page's query parameters?
-        context.requestParams.get(binding.name) match {
-          // Yep -- process that
-          case Some(phrase) => processPhrase(phrase.ops, context, true)
-          // Okay, this really seems to be an unbound value, so give an error:
-          case None => warningFut(context, s"Didn't find a value for ${binding.name}")
-        }          
-      }
-    }
-  }
-  
-  private def processInternalBinding(binding:QLBinding, context:QLContext, isParam:Boolean, resolvingParser:QLParser):Future[QLContext] = {
-    if (binding.name == "_context") {
-      val scopes = context.scopes(this)
-      Future.successful(resolvingParser.initialContext.withScopes(this, scopes))
-    } else if (binding.name == "_defining") {
-      // If this expression was invoked with a defining context, produce that:
-      val found = for {
-        inv <- invOpt
-        defining <- inv.definingContext
-      }
-        yield defining
-        
-      Future.successful(found.getOrElse(context.next(Core.emptyOpt(Core.LinkType))))
-    } else {
-      try {
-        val rawParamNum = Integer.parseInt(binding.name.substring(1))
-        val paramNum = rawParamNum - 1
-        val resultOpt = for {
-          params <- resolvingParser.paramsOpt
-          param = params(paramNum)
-        }
-          yield {
-            param.resolved match {
-              // This parameter was resolved at the call site ("!")
-              case Some(resolved) => Future.successful(resolved)
-              // Normal parameter -- resolve it here:
-              // TODO: the isParam parameter we're using here is a horrible, opaque hack.
-              // Disentangle it, and figure out a better approach:
-              case None => processExp(param.exp, context, true)
-            }
-          }
-        
-        resultOpt.getOrElse(warningFut(context,"No parameters passed in"))
-      } catch {
-        case ex:NumberFormatException => warningFut(context, "$" + binding.name + " is not a valid bound name")
-        case ex:IndexOutOfBoundsException => warningFut(context, "Not enough parameters passed in")
-      }
-    }
-  }
-  
-  private def processBinding(binding:QLBinding, context:QLContext, isParam:Boolean, call:QLCall):Future[QLContext] = {
-    // What is this? The thing is, bindings are complicated. Iff we are in a subparser, *and* we are resolving
-    // the parameters from that subparser, then we need to be resolving the bindings against the *parent*, not
-    // against this parser. That is, "myMethod($_1)"'s parameter is parameter 1 from the *caller*. Our normal
-    // resolution would be against the *callee*.
-    val resolvingParser = {
-      if (invOpt.isDefined && isParam)
-        invOpt.flatMap(_.context.parser).get
-      else
-        this
-    }
-  
-    if (binding.name.startsWith("_"))
-      processInternalBinding(binding, context, isParam, resolvingParser)
-    else
-      processNormalBinding(binding, context, isParam, resolvingParser, call)
-  }
-  
-  private def processNumber(num:QLNumber, context:QLContext):QLContext = {
-    if (num.n >= Integer.MAX_VALUE || num.n <= Integer.MIN_VALUE)
-      context.next(Core.ExactlyOne(Core.LongType(num.n)))
-    else
-      context.next(Core.ExactlyOne(Core.IntType(num.n.toInt)))
-  }
-  
-  // TODO: this is now obsolete, since List Literals now desugar to _concat, so I think it can
-  // be deleted:
-  private def processListLiteral(list:QLListLiteral, context:QLContext):Future[QLContext] = {
-    // Process all of the list elements, in parallel:
-    val futs:Seq[Future[Seq[QLContext]]] = list.exps.map(processExpAll(_, context))
-    val fut:Future[Seq[QLContext]] = Future.sequence(futs).map(_.flatten)
-    // Extract all the elements, and merge them into one list
-    fut.map { contexts =>
-      val qvs = contexts.map(_.value)
-      val pt = qvs.headOption.map(_.pType).getOrElse(Core.UnknownType)
-      val elems = qvs.flatMap(_.elems)
-      val qv = Core.QList.makePropValue(elems, pt)
-      context.next(qv)
-    }
-  }
-  
-  private def processTextBlockLiteral(contextIn: QLContext, block: QLTextBlockLiteral): Future[QLContext] = {
-    fut(contextIn.next(QL.WikitextValue(Wikitext(s"```${block.text}```"))))
-  }
-  
-  private def processStage(stage:QLStage, contextIn:QLContext, isParam:Boolean):Future[QLContext] = {
-    logStage(stage, contextIn) {
-      if (contextIn.depth > contextIn.maxDepth) {
-        Future.successful(
-          contextIn.next(WarningValue("Too many levels of calls -- you can only have up to " + contextIn.maxDepth + " calls in a phrase.")))
-      } else {
-        val context =
-          if (stage.useCollection)
-            contextIn.asCollection
-          else if (stage.clearUseCollection)
-            contextIn.clearAsCollection
-          else
-            contextIn
-        stage match {
-          case name: QLCall => processCall(name, context, isParam)
-          case subText: QLTextStage => processTextStage(subText, context)
-          case num: QLNumber => Future.successful(processNumber(num, context))
-          case list: QLListLiteral => processListLiteral(list, context)
-          case QLExpStage(exp) => processExp(exp, context)
-          case block: QLTextBlockLiteral => processTextBlockLiteral(contextIn, block)
-        }
-      }
-    }
-  }
-  
-  def processPhrase(ops:Seq[QLStage], context:QLContext, isParam:Boolean = false):Future[QLContext] = {
-    if (context.isCut)
-      // Setting the "cut" flag means that we're just stopping processing here. Usually
-      // used for warnings:
-      Future.successful(context)
-    else {
-      if (ops.isEmpty)
-        Future.successful(context)
-      else
-        processStage(ops.head, context, isParam) flatMap { next => processPhrase(ops.tail, next, isParam) }
-    }
-  }
-  
-  /**
-   * Wraps the given function in a new scope, which will get popped once the operation completes.
-   */
-  def withScope(contextIn:QLContext, f: QLContext => Future[QLContext]):Future[QLContext] = {
-    val newScopes = contextIn.scopes.get(this).getOrElse(QLScopes()).push
-    val allScopes = contextIn.scopes + (this -> newScopes)
-    val context = contextIn.copy(scopes = allScopes)(contextIn.state, contextIn.ecology)
-    f(context).map { contextOut =>
-      contextOut.withScopes(this, contextOut.scopes(this).pop)
-    }
-  }
-  
-  /**
-   * Variant of processPhrase that treats the phrase as its own distinct scope, which will be discarded when
-   * we reach the end of processing.
-   */
-  def processPhraseAsScope(ops:Seq[QLStage], contextIn:QLContext, isParam:Boolean = false):Future[QLContext] = {
-    withScope(contextIn, processPhrase(ops, _, isParam))
-  }
-  
-  private def processPhrases(phrases:Seq[QLPhrase], context:QLContext, isParam:Boolean = false):Future[Seq[QLContext]] = {
-    val defaultScopes = context.scopes.get(this).getOrElse(QLScopes())
-    (fut(Seq.empty[QLContext]) /: phrases) { (prev, phrase) =>
-      prev.flatMap { contexts =>
-        val prevContextOpt = contexts.lastOption
-        prevContextOpt match {
-          case Some(last) if (last.isError) => {
-            // We've already gotten an error, so just ignore everything else and return what
-            // we had up until there:
-            fut(contexts)
-          }
-          case _ => {
-            // Normal situation -- process the next context
-            // Pull in the accumulated bindings from the last context, if there are any:
-            val prevScopes = prevContextOpt.flatMap(_.scopes.get(this)).getOrElse(defaultScopes)
-            // Actually process this phrase:
-            val processedFut = processPhrase(phrase.ops, context.withScopes(this, prevScopes), isParam)
-            processedFut.map { processed =>
-              val thisContext = phrase.ops.last match {
-                case QLCall(QLBindingDef(n, _, _), _, _, _) => {
-                  // The last Stage of this Phrase was an assignment; in this very special case, we
-                  // suppress the output *unless* it was an error:
-                  if (processed.isError)
-                    processed
-                  else
-                    processed.next(Core.QNone) 
-                }
-                // Normal result: just return what we just processed:
-                case _ => processed
-              }
-              // Tack it onto the list, and we're ready to go...
-              contexts :+ thisContext
-            }
-          }
-        }
-      }
-    }
-  }
-  
-  def processExpAll(exp:QLExp, context:QLContext, isParam:Boolean = false):Future[Seq[QLContext]] = {
-    processPhrases(exp.phrases, context, isParam)
-  }
-  
-  def processExp(exp:QLExp, context:QLContext, isParam:Boolean = false):Future[QLContext] = {
-    // TODO: for the moment, we're only coping with the final resulting Context here. That is
-    // *usually* what you want, but certainly more restrictive than the official semantics of QL.
-    // Figure out how to make the callers of this cope with Seq[Future[QLContext]] (or Future[Seq[QLContext]]),
-    // and adjust this to produce that.
-    processExpAll(exp, context, isParam).map { contexts =>
-      if (contexts.isEmpty)
-        // This probably means that the expression was completely empty -- for example, an
-        // empty parameter. So we treat this as simply empty.
-        context.next(EmptyValue.untyped)
-      else
-        contexts.last
-    }
-  }
-  
-  def processExpAsScope(exp:QLExp, context:QLContext):Future[QLContext] = {
-    withScope(context, processExp(exp, _))
-  }
 
-  // Note that the returned Future here is guaranteed to be successful -- Exceptions are already rendered.
-  def contextsToWikitext(contextsFut:Future[Seq[QLContext]], insertNewlines:Boolean = false):Future[Wikitext] = {
-    // Wikify each of them:
-    val wikified = contextsFut.flatMap { contexts =>
-      Future.sequence(contexts.map(context => context.value.wikify(context.parent)))
-    }
-    // And merge them together:
-    wikified
-      .map { contexts => (Wikitext("") /: contexts) (_.+(_, insertNewlines)) }
-      // Iff the Future contains an Exception, render that here. This is how we display errors in-place,
-      // instead of having them propagate out to overwhelm the page:
-      .recoverWith {
-        case ex:PublicException => warningFut(initialContext, ex.display(initialContext.requestOpt)).flatMap(_.value.wikify(initialContext))
-      }
-  }
-  
-  /**
-   * This deals with QText that contains "__stuff__" or "____", both of which render as
-   * the value of the received context.
-   * 
-   * The key notion here is that the wikify() method takes an optional "displayOpt" parameter.
-   * If specified, this says how to display the passed-in value. It doesn't make sense for all
-   * Types, but it is always *syntactically* legal, and is provided as a tool for any Type that
-   * wants to avail itself of this notion.
-   */
-  private def linkToWikitext(contents:ParsedQLText, context:QLContext):Future[Wikitext] = {
-    contents.parts.length match {
-      // Just four underscores, which means we don't do anything special for the display:
-      case 0 => context.value.wikify(context, None)
-      // There is content, so pass that down as the display:
-      case _ => processParseTree(contents, context).flatMap(guts => context.value.wikify(context, Some(guts)))
-    }
-  }
-  
-  private def processParseTree(parseTree:ParsedQLText, context:QLContext):Future[Wikitext] = {
-    // Note that the parts at this level are independent -- the context doesn't carry over -- which
-    // makes this relatively easy. We just compute each piece, and then fold them together:
-    val futures = parseTree.parts.map { part =>
-      part match {
-        case UnQLText(t) => Future.successful(Wikitext(t))
-        case QLExp(phrases) => contextsToWikitext(processPhrases(phrases, context))
-        case QLLink(l) => linkToWikitext(l, context)
-      }          
-    }
-    Future.fold(futures)(Wikitext(""))(_ + _)
-  }
-  
   /**
    * Wrapper around all text parsing. Deals with both profiling and memoizing the result.
    */
-  private def parseMemoized[T <: QLParseResultVal](parser:Parser[T]):QLParseResult[T] = {
-    qlProfilers.parse.profile { 
+  private def parseMemoized[T <: QLParseResultVal](parser: Parser[T]): QLParseResult[T] = {
+    qlProfilers.parse.profile {
       input.memoizedParse {
         val result = parseAll(parser, input.text)
         result match {
           case Success(result, _) => QLParseSuccess(result)
           case Failure(msg, next) => QLParseFailure(renderError(msg, next))
           // TODO: we should probably do something more serious in case of Error:
-          case Error(msg, next) => QLParseFailure { QLog.error("Couldn't parse qlText: " + msg); renderError(msg, next) }
+          case Error(msg, next) =>
+            QLParseFailure { QLog.error("Couldn't parse qlText: " + msg); renderError(msg, next) }
         }
       }
     }
   }
-  
+
   def parse = parseMemoized(qlText)
-  
-  def consumeReader[T](reader:scala.util.parsing.input.Reader[T]):String = {
+
+  def consumeReader[T](reader: scala.util.parsing.input.Reader[T]): String = {
     reader.first.toString + (if (reader.atEnd) "" else consumeReader(reader.rest))
   }
-  
+
   // TODO: this really shouldn't be showing raw HTML. Redo this properly as Wikitext:
-  def renderError(msg:String, reader:scala.util.parsing.input.Reader[_]):Future[Wikitext] = {
+  def renderError(
+    msg: String,
+    reader: scala.util.parsing.input.Reader[_]
+  ): Future[Wikitext] = {
     val pos = reader.pos
-    val propStr = initialContext.getProp match {
+    val propStr = parserContext.getProp match {
       case Some(prop) => " " + prop.displayName + ", "
-      case None => ""
+      case None       => ""
     }
     val escapedMsg = s"<b>Syntax error in $propStr line ${pos.line}:</b> " + scala.xml.Utility.escape(msg)
     val escapedError = scala.xml.Utility.escape(pos.longString)
     Future.successful(HtmlWikitext(QHtml(
-        "<p>" + escapedMsg + ":<p>\n" +
-        "<pre>" + escapedError + "</pre>\n")))
+      "<p>" + escapedMsg + ":<p>\n" +
+        "<pre>" + escapedError + "</pre>\n"
+    )))
   }
-  
-  def wikiFut(str:String):Future[Wikitext] =
+
+  def wikiFut(str: String): Future[Wikitext] =
     Future.successful(Wikitext(str))
-  
-  def process:Future[Wikitext] = {
+
+  def process: Future[Wikitext] = {
     try {
       val parseResult = parse
       parseResult match {
         case QLParseSuccess(result) => {
-          processParseTree(result, initialContext)
+          val context = processor.initialContext
+          processor.processParseTree(result, context)
             .recoverWith {
-              case ex:PublicException => WarningValue(ex.display(initialContext.requestOpt)).wikify(initialContext)
+              case ex: PublicException => WarningValue(ex.display(context.requestOpt)).wikify(context)
             }
         }
         case QLParseFailure(msgFut) => msgFut
       }
     } catch {
-      case overflow:java.lang.StackOverflowError => {
+      case overflow: java.lang.StackOverflowError => {
         QLog.error("Stack overflow error while trying to parse this QLText:\n" + input.text)
         overflow.printStackTrace()
-        wikiFut("We're sorry -- this thing is apparently more complex than Querki can currently cope with. Please contact Justin: this is a bug we need to fix.")
+        wikiFut(
+          "We're sorry -- this thing is apparently more complex than Querki can currently cope with. Please contact Justin: this is a bug we need to fix."
+        )
       }
-      case error:Exception => {
+      case error: Exception => {
         QLog.error("Exception during QL Processing: " + error, error)
         wikiFut("We're sorry -- there was an error while trying to display this thing.")
       }
-      case error:Throwable => {
+      case error: Throwable => {
         QLog.error("Throwable during QL Processing: " + error, error)
         wikiFut("We're sorry -- there was a serious error while trying to display this thing.")
       }
     }
   }
-  
-  def parsePhrase():Option[QLPhrase] = {
+
+  def parsePhrase(): Option[QLPhrase] = {
     val parseResult = parseMemoized(qlPhrase)
     parseResult match {
       case QLParseSuccess(result) => Some(result)
-      case _ => None
+      case _                      => None
     }
   }
-  
-  private[ql] def processMethodToWikitext:Future[Wikitext] = {
+
+  private[ql] def processMethodToWikitext: Future[Wikitext] = {
     val parseResult = parseMemoized(qlExp)
     parseResult match {
-      case QLParseSuccess(result) => 
-        qlProfilers.processMethod.profile { 
-          contextsToWikitext(processExpAll(result, initialContext, false), false)
+      case QLParseSuccess(result) =>
+        qlProfilers.processMethod.profile {
+          processor.contextsToWikitext(processor.processExpAll(result, processor.initialContext, false), false)
         }
-      case QLParseFailure(msgFut) => { msgFut.flatMap(err => initialContext.next(QL.WikitextValue(err)).value.wikify(initialContext)) }
+      case QLParseFailure(msgFut) => {
+        msgFut.flatMap(err => parserContext.next(QL.WikitextValue(err)).value.wikify(parserContext))
+      }
     }
   }
-  
-  private[ql] def processMethod:Future[QLContext] = {
+
+  private[ql] def processMethod: Future[QLContext] = {
     val parseResult = parseMemoized(qlExp)
     parseResult match {
-      case QLParseSuccess(result) => 
-        qlProfilers.processMethod.profile { 
-          processExp(result, initialContext, false)
-          .recoverWith {
-            case ex:PublicException => warningFut(initialContext, ex.display(initialContext.requestOpt))
-          }
+      case QLParseSuccess(result) =>
+        qlProfilers.processMethod.profile {
+          val context = processor.initialContext
+          processor.processExp(result, context, false)
+            .recoverWith {
+              case ex: PublicException => processor.warningFut(context, ex.display(context.requestOpt))
+            }
         }
-      case QLParseFailure(msgFut) => { msgFut.map(err => initialContext.next(QL.WikitextValue(err))) }
+      case QLParseFailure(msgFut) => { msgFut.map(err => parserContext.next(QL.WikitextValue(err))) }
     }
   }
+
+  def processExp(
+    exp: QLExp,
+    context: QLContext,
+    isParam: Boolean = false
+  ): Future[QLContext] = processor.processExp(exp, context, isParam)
+
+  def processExpAsScope(
+    exp: QLExp,
+    context: QLContext
+  ): Future[QLContext] = {
+    processor.withScope(context, processExp(exp, _))
+  }
+
 }

--- a/querki/scalajvm/app/querki/ql/QLProcessor.scala
+++ b/querki/scalajvm/app/querki/ql/QLProcessor.scala
@@ -33,6 +33,13 @@ class QLProcessor(
   val initialContext =
     ci.copy(scopes = ci.scopes + (this -> initialScopes.push))(ci.state, ecology)
 
+  // *****************************************
+  //
+  // Context Logging
+  //
+  // Crude but useful debugging of the process tree. Could stand to be beefed up when I have time
+  //
+
   // A unique ID that we attach to each Stage, for understanding what's going on:
   val stageId = new java.util.concurrent.atomic.AtomicInteger()
   // Turn this to true to produce voluminous output from the QL processing pipeline

--- a/querki/scalajvm/app/querki/ql/QLProcessor.scala
+++ b/querki/scalajvm/app/querki/ql/QLProcessor.scala
@@ -1,0 +1,626 @@
+package querki.ql
+
+import models.{Thing, ThingId, Wikitext}
+import querki.values.{EmptyValue, QLContext, QValue}
+import querki.globals.{fut, Config, Ecology, EcologyMember, Future, PublicException, QLog}
+
+import scala.concurrent.ExecutionContext
+
+class QLProcessor(
+  ci: QLContext,
+  invOpt: Option[Invocation] = None,
+  parserOpt: Option[QLParser] = None,
+  val initialBindings: Option[Map[String, QValue]] = None
+)(implicit
+  val ecology: Ecology,
+  ec: ExecutionContext
+) extends EcologyMember {
+
+  lazy val Core = interface[querki.core.Core]
+  lazy val QL = interface[querki.ql.QL]
+  lazy val QLInternals = interface[QLInternals]
+
+  lazy val ExactlyOne = Core.ExactlyOne
+  lazy val qlProfilers = QLInternals.qlProfilers
+  def WarningValue = QL.WarningValue _
+
+  lazy val initialScopes = initialBindings match {
+    case Some(bindings) => QLScopes(List(QLScope(bindings)))
+    case None           => QLScopes()
+  }
+
+  // Add this processor to the scope stack:
+  val initialContext =
+    ci.copy(scopes = ci.scopes + (this -> initialScopes.push))(ci.state, ecology)
+
+  // A unique ID that we attach to each Stage, for understanding what's going on:
+  val stageId = new java.util.concurrent.atomic.AtomicInteger()
+  // Turn this to true to produce voluminous output from the QL processing pipeline
+  val doLogContext = Config.getBoolean("querki.test.logContexts", false)
+
+  def logStage(
+    stage: QLStage,
+    context: QLContext
+  )(
+    processor: => Future[QLContext]
+  ): Future[QLContext] = {
+    if (doLogContext) {
+      try {
+        val sid = stageId.getAndIncrement
+        val indent = "  " * context.depth
+        QLog.info(s"$indent$sid: [[${stage.reconstructString}]] on ${context.debugRender}")
+        val result = processor
+        result.onComplete {
+          case scala.util.Success(result) =>
+            QLog.info(s"$indent$sid = ${result.debugRender}")
+          case scala.util.Failure(ex) =>
+            QLog.error(s"$indent$sid returned Failure!", ex)
+        }
+        result
+      } catch {
+        case th: Throwable => {
+          QLog.error(
+            s"Exception while processing stage ${stage.reconstructString} with context ${context.debugRender}",
+            th
+          )
+          throw th
+        }
+      }
+    } else
+      processor
+  }
+
+  /**
+   * Note that the output here is nominally a new Context, but the underlying type is
+   * ParsedTextType. So far, you can't *do* anything with that afterwards other than
+   * render it, which just returns the already-computed Wikitext.
+   */
+  private def processTextStage(
+    text: QLTextStage,
+    context: QLContext
+  ): Future[QLContext] = {
+    val ct = context.value.cType
+    // For each element of the incoming context, recurse in and process the embedded Text
+    // in that context. Iff the context is empty, though, just produce an empty result *unless*
+    // they have asked for the full collection.
+    val transformedFuts =
+      if (context.isEmpty && text.collFlag.isEmpty)
+        Iterable.empty
+      else
+        context.map { elemContext =>
+          processParseTree(text.contents, elemContext).map(QL.ParsedTextType(_))
+        }
+
+    val transformedFut = Future.sequence(transformedFuts)
+
+    // TBD: the asInstanceOf here is surprising -- I would have expected transformed to come out
+    // as the right type simply by type signature. Can we get rid of it?
+    transformedFut.map(transformed =>
+      context.next(ct.makePropValue(transformed.asInstanceOf[ct.implType], QL.ParsedTextType))
+    )
+  }
+
+  private def processCall(
+    call: QLCall,
+    context: QLContext,
+    isParam: Boolean
+  ): Future[QLContext] = {
+
+    def lookupMethod(): Future[Option[Thing]] = {
+      call.methodName match {
+        case Some(qlName) => {
+          qlName match {
+            case binding: QLBinding => {
+              processBinding(binding, context, isParam, call).map { resolvedBinding =>
+                if (resolvedBinding.value.matchesType(Core.LinkType)) {
+                  for {
+                    // TODO: for now, we don't cope with multiple resolved results here. I'm not even
+                    // sure why you'd ever want that:
+                    oid <- resolvedBinding.value.rawList(Core.LinkType).headOption
+                    thing <- context.state.anything(oid)
+                  } yield thing
+                } else {
+                  None
+                }
+              }
+            }
+            case tid: QLThingId => Future.successful(context.state.anything(ThingId(tid.name)))
+            case _              => Future.successful(context.state.anythingByName(qlName.name))
+          }
+        }
+        case None => Future.successful(None)
+      }
+    }
+
+    def processThing(
+      t: Thing,
+      context: QLContext
+    ): Future[QLContext] = qlProfilers.processThing.profile {
+      // If there are parameters to the call, they are a collection of phrases. If any are marked immediate
+      // (prefixed with "!"), they gets processed *now*, rather than meta-programmed later:
+      val paramsFOpt: Option[Seq[Future[QLParam]]] = call.params.map { params =>
+        params.map { param =>
+          if (param.immediate) {
+            processExp(param.exp, context).map { processed =>
+              param.copy(resolved = Some(processed))
+            }
+          } else
+            Future.successful(param)
+        }
+      }
+      val paramsFut: Future[Option[Seq[QLParam]]] = paramsFOpt match {
+        case Some(paramsSeq) => {
+          Future.sequence(paramsSeq).map(Some(_))
+        }
+        case None => Future.successful(None)
+      }
+      paramsFut.flatMap { params =>
+        lookupMethod().flatMap {
+          case Some(method) => {
+            val definingContext = context.next(Core.ExactlyOne(Core.LinkType(t.id)))
+            qlProfilers.processCallDetail.profileAs(" " + call.name.name) {
+              method.qlApplyTop(
+                InvocationImpl(t, method, context.withCall(call, method), Some(definingContext), params),
+                method
+              )
+            }
+          }
+          case None => {
+            qlProfilers.processCallDetail.profileAs(" " + call.name.name) {
+              val inv = InvocationImpl(t, t, context.withCall(call, t), None, params)
+              t.qlApplyTop(inv, t)
+            }
+          }
+        }
+      }
+    }
+
+    call.name match {
+      case binding: QLBinding => {
+        processBinding(binding, context, isParam, call).flatMap { resolvedBinding =>
+          if (resolvedBinding.value.matchesType(Core.LinkType)) {
+            val resultFuts = for {
+              oid <- resolvedBinding.value.rawList(Core.LinkType)
+              thing <- context.state.anything(oid)
+              fut = processThing(thing, context)
+            } yield fut
+
+            val resultFut = Future.sequence(resultFuts)
+            resultFut.map(results => resolvedBinding.concat(results))
+          } else {
+            Future.successful(resolvedBinding)
+          }
+        }
+      }
+      case bindingDef: QLBindingDef => {
+        processBindingDef(bindingDef, context)
+      }
+      case tid: QLThingId => {
+        // Note: this is structured to fix QI.7w4g8tv: cope if the tid *looks* like an OID, but
+        // doesn't parse right:
+        ThingId.parseOpt(tid.name).map { thingId =>
+          context.state.anything(thingId) match {
+            case Some(t) => processThing(t, context)
+            case None    => Future.failed(new PublicException("QL.unknownThingId", tid.reconstructString))
+          }
+        }.getOrElse(Future.failed(new PublicException("QL.unknownThingId", tid.reconstructString)))
+      }
+      case _ => {
+        // Looking up a Thing by name, which is the most common situation:
+        context.state.anythingByName(call.name.name) match {
+          // Normal case: we found this Thing by name:
+          case Some(t) => processThing(t, context)
+          // We *didn't* find the Thing...
+          case None => {
+            // Note: before QI.9v5kelv, we distinguished depending on whether call.name.name was a known Tag
+            // (in which case we returned UnknownNameType) or not (in which case we raised the
+            // "QL.unknownName" error). We now only do the former -- the latter has simply proven to be
+            // annoying without much benefit. (We also allowed backtick-delimited names even if they were
+            // unknown, which was *way* too subtle.)
+            Future.successful(context.next(Core.ExactlyOne(QL.UnknownNameType(call.name.name))))
+          }
+        }
+      }
+    }
+  }
+
+  def warningFut(
+    context: QLContext,
+    msg: String
+  ): Future[QLContext] = {
+    Future.successful(context.next(WarningValue(msg)))
+  }
+
+  private def processBindingDef(
+    binding: QLBindingDef,
+    context: QLContext
+  ): Future[QLContext] = {
+    context.scopes.get(this).map { scopes =>
+      val boundOpt = scopes.lookup(binding.name)
+      if (boundOpt.isDefined) {
+        warningFut(
+          context,
+          s"Attempting to reassign ${"$" + binding.name} -- you may only say ${"+$" + binding.name} once"
+        )
+      } else {
+        // Okay -- we are legally attempting to bind this name to the received value:
+        val newScopes: QLScopes =
+          binding.func match {
+            case Some(func) => {
+              // We're binding a local function, so we ignore the context and instead just use that:
+              val closure = QLClosure(QLExp(Seq(func)), binding.params)
+              val v = ExactlyOne(QL.ClosureType(closure))
+              scopes.bind((binding.name -> v))
+            }
+            // Ordinary binding, so we just bind the current context to this name:
+            case _ => scopes.bind((binding.name -> context.value))
+          }
+        val newContext = context.withScopes(this, newScopes)
+        fut(newContext)
+      }
+    }.getOrElse {
+      QLog.error(s"Failed to find the scope for binding $binding!")
+      warningFut(context, s"Internal error while trying to parse!")
+    }
+  }
+
+  private def processNormalBinding(
+    binding: QLBinding,
+    context: QLContext,
+    isParam: Boolean,
+    call: QLCall
+  ): Future[QLContext] = {
+    val scopes = context.scopes(this)
+    val boundOpt = scopes.lookup(binding.name)
+    boundOpt match {
+      // Fetching an already-bound value
+      case Some(bound) => {
+        if (bound.pType == QL.ClosureType) {
+          // We're invoking a local function, so process that:
+          val closure = bound.firstAs(QL.ClosureType).get
+          closure.params match {
+            case Some(formals) => {
+              // There are formal parameters for the function, so we need to bind those to the actuals:
+              val actuals = call.params.getOrElse(
+                throw new Exception(s"Locally-defined function ${binding.name} requires parameters.")
+              )
+              // The number of params must match exactly, since we don't have optional params yet:
+              if (formals.length != actuals.length)
+                throw new Exception(s"Locally-defined function ${binding.name} requires ${formals.length} parameters.")
+              val actualVs = actuals.map { actual => ExactlyOne(QL.ClosureType(QLClosure(actual.exp, None))) }
+              val pairs = formals.zip(actualVs)
+              withScope(
+                context,
+                { scopedContext =>
+                  val newScopes = (scopedContext.scopes(this) /: pairs) { (scopes, pair) =>
+                    scopes.bind(pair)
+                  }
+                  processExp(closure.exp, scopedContext.withScopes(this, newScopes))
+                }
+              )
+            }
+            // An ordinary closure value, which just gets evaluated with the context:
+            case None => processExp(closure.exp, context)
+          }
+        } else {
+          // Normal value -- just stick it in:
+          fut(context.next(bound))
+        }
+      }
+      case None => {
+        // It's not bound lexically. Does it exist in the page's query parameters?
+        context.requestParams.get(binding.name) match {
+          // Yep -- process that
+          case Some(phrase) => processPhrase(phrase.ops, context, true)
+          // Okay, this really seems to be an unbound value, so give an error:
+          case None => warningFut(context, s"Didn't find a value for ${binding.name}")
+        }
+      }
+    }
+  }
+
+  private def processInternalBinding(
+    binding: QLBinding,
+    context: QLContext,
+    isParam: Boolean,
+    resolvingParserOpt: Option[QLParser]
+  ): Future[QLContext] = {
+    if (binding.name == "_context") {
+      val scopes = context.scopes(this)
+      resolvingParserOpt match {
+        case Some(resolvingParser) => Future.successful(resolvingParser.parserContext.withScopes(this, scopes))
+        case None                  => Future.successful(initialContext.withScopes(this, scopes))
+      }
+    } else if (binding.name == "_defining") {
+      // If this expression was invoked with a defining context, produce that:
+      val found = for {
+        inv <- invOpt
+        defining <- inv.definingContext
+      } yield defining
+
+      Future.successful(found.getOrElse(context.next(Core.emptyOpt(Core.LinkType))))
+    } else {
+      try {
+        val rawParamNum = Integer.parseInt(binding.name.substring(1))
+        val paramNum = rawParamNum - 1
+        val resultOpt = for {
+          resolvingParser <- resolvingParserOpt
+          params <- resolvingParser.paramsOpt
+          param = params(paramNum)
+        } yield {
+          param.resolved match {
+            // This parameter was resolved at the call site ("!")
+            case Some(resolved) => Future.successful(resolved)
+            // Normal parameter -- resolve it here:
+            // TODO: the isParam parameter we're using here is a horrible, opaque hack.
+            // Disentangle it, and figure out a better approach:
+            case None => processExp(param.exp, context, true)
+          }
+        }
+
+        resultOpt.getOrElse(warningFut(context, "No parameters passed in"))
+      } catch {
+        case ex: NumberFormatException     => warningFut(context, "$" + binding.name + " is not a valid bound name")
+        case ex: IndexOutOfBoundsException => warningFut(context, "Not enough parameters passed in")
+      }
+    }
+  }
+
+  private def processBinding(
+    binding: QLBinding,
+    context: QLContext,
+    isParam: Boolean,
+    call: QLCall
+  ): Future[QLContext] = {
+    // What is this? The thing is, bindings are complicated. Iff we are in a subparser, *and* we are resolving
+    // the parameters from that subparser, then we need to be resolving the bindings against the *parent*, not
+    // against this parser. That is, "myMethod($_1)"'s parameter is parameter 1 from the *caller*. Our normal
+    // resolution would be against the *callee*.
+    val resolvingParserOpt = {
+      if (invOpt.isDefined && isParam)
+        invOpt.flatMap(_.context.parser)
+      else
+        parserOpt
+    }
+
+    if (binding.name.startsWith("_"))
+      processInternalBinding(binding, context, isParam, resolvingParserOpt)
+    else
+      processNormalBinding(binding, context, isParam, call)
+  }
+
+  /**
+   * This deals with QText that contains "__stuff__" or "____", both of which render as
+   * the value of the received context.
+   *
+   * The key notion here is that the wikify() method takes an optional "displayOpt" parameter.
+   * If specified, this says how to display the passed-in value. It doesn't make sense for all
+   * Types, but it is always *syntactically* legal, and is provided as a tool for any Type that
+   * wants to avail itself of this notion.
+   */
+  private def linkToWikitext(
+    contents: ParsedQLText,
+    context: QLContext
+  ): Future[Wikitext] = {
+    contents.parts.length match {
+      // Just four underscores, which means we don't do anything special for the display:
+      case 0 => context.value.wikify(context, None)
+      // There is content, so pass that down as the display:
+      case _ => processParseTree(contents, context).flatMap(guts => context.value.wikify(context, Some(guts)))
+    }
+  }
+
+  def processParseTree(
+    parseTree: ParsedQLText,
+    context: QLContext
+  ): Future[Wikitext] = {
+    // Note that the parts at this level are independent -- the context doesn't carry over -- which
+    // makes this relatively easy. We just compute each piece, and then fold them together:
+    val futures = parseTree.parts.map { part =>
+      part match {
+        case UnQLText(t)    => Future.successful(Wikitext(t))
+        case QLExp(phrases) => contextsToWikitext(processPhrases(phrases, context))
+        case QLLink(l)      => linkToWikitext(l, context)
+      }
+    }
+    Future.fold(futures)(Wikitext(""))(_ + _)
+  }
+
+  private def processNumber(
+    num: QLNumber,
+    context: QLContext
+  ): QLContext = {
+    if (num.n >= Integer.MAX_VALUE || num.n <= Integer.MIN_VALUE)
+      context.next(Core.ExactlyOne(Core.LongType(num.n)))
+    else
+      context.next(Core.ExactlyOne(Core.IntType(num.n.toInt)))
+  }
+
+  // TODO: this is now obsolete, since List Literals now desugar to _concat, so I think it can
+  // be deleted:
+  private def processListLiteral(
+    list: QLListLiteral,
+    context: QLContext
+  ): Future[QLContext] = {
+    // Process all of the list elements, in parallel:
+    val futs: Seq[Future[Seq[QLContext]]] = list.exps.map(processExpAll(_, context))
+    val fut: Future[Seq[QLContext]] = Future.sequence(futs).map(_.flatten)
+    // Extract all the elements, and merge them into one list
+    fut.map { contexts =>
+      val qvs = contexts.map(_.value)
+      val pt = qvs.headOption.map(_.pType).getOrElse(Core.UnknownType)
+      val elems = qvs.flatMap(_.elems)
+      val qv = Core.QList.makePropValue(elems, pt)
+      context.next(qv)
+    }
+  }
+
+  private def processTextBlockLiteral(
+    contextIn: QLContext,
+    block: QLTextBlockLiteral
+  ): Future[QLContext] = {
+    fut(contextIn.next(QL.WikitextValue(Wikitext(s"```${block.text}```"))))
+  }
+
+  private def processStage(
+    stage: QLStage,
+    contextIn: QLContext,
+    isParam: Boolean
+  ): Future[QLContext] = {
+    logStage(stage, contextIn) {
+      if (contextIn.depth > contextIn.maxDepth) {
+        Future.successful(
+          contextIn.next(WarningValue(
+            "Too many levels of calls -- you can only have up to " + contextIn.maxDepth + " calls in a phrase."
+          ))
+        )
+      } else {
+        val context =
+          if (stage.useCollection)
+            contextIn.asCollection
+          else if (stage.clearUseCollection)
+            contextIn.clearAsCollection
+          else
+            contextIn
+        stage match {
+          case name: QLCall              => processCall(name, context, isParam)
+          case subText: QLTextStage      => processTextStage(subText, context)
+          case num: QLNumber             => Future.successful(processNumber(num, context))
+          case list: QLListLiteral       => processListLiteral(list, context)
+          case QLExpStage(exp)           => processExp(exp, context)
+          case block: QLTextBlockLiteral => processTextBlockLiteral(contextIn, block)
+        }
+      }
+    }
+  }
+
+  def processPhrase(
+    ops: Seq[QLStage],
+    context: QLContext,
+    isParam: Boolean = false
+  ): Future[QLContext] = {
+    if (context.isCut)
+      // Setting the "cut" flag means that we're just stopping processing here. Usually
+      // used for warnings:
+      Future.successful(context)
+    else {
+      if (ops.isEmpty)
+        Future.successful(context)
+      else
+        processStage(ops.head, context, isParam).flatMap { next => processPhrase(ops.tail, next, isParam) }
+    }
+  }
+
+  private def processPhrases(
+    phrases: Seq[QLPhrase],
+    context: QLContext,
+    isParam: Boolean = false
+  ): Future[Seq[QLContext]] = {
+    val defaultScopes = context.scopes.get(this).getOrElse(QLScopes())
+    (fut(Seq.empty[QLContext]) /: phrases) { (prev, phrase) =>
+      prev.flatMap { contexts =>
+        val prevContextOpt = contexts.lastOption
+        prevContextOpt match {
+          case Some(last) if (last.isError) => {
+            // We've already gotten an error, so just ignore everything else and return what
+            // we had up until there:
+            fut(contexts)
+          }
+          case _ => {
+            // Normal situation -- process the next context
+            // Pull in the accumulated bindings from the last context, if there are any:
+            val prevScopes = prevContextOpt.flatMap(_.scopes.get(this)).getOrElse(defaultScopes)
+            // Actually process this phrase:
+            val processedFut = processPhrase(phrase.ops, context.withScopes(this, prevScopes), isParam)
+            processedFut.map { processed =>
+              val thisContext = phrase.ops.last match {
+                case QLCall(QLBindingDef(n, _, _), _, _, _) => {
+                  // The last Stage of this Phrase was an assignment; in this very special case, we
+                  // suppress the output *unless* it was an error:
+                  if (processed.isError)
+                    processed
+                  else
+                    processed.next(Core.QNone)
+                }
+                // Normal result: just return what we just processed:
+                case _ => processed
+              }
+              // Tack it onto the list, and we're ready to go...
+              contexts :+ thisContext
+            }
+          }
+        }
+      }
+    }
+  }
+
+  def processExpAll(
+    exp: QLExp,
+    context: QLContext,
+    isParam: Boolean = false
+  ): Future[Seq[QLContext]] = {
+    processPhrases(exp.phrases, context, isParam)
+  }
+
+  def processExp(
+    exp: QLExp,
+    context: QLContext,
+    isParam: Boolean = false
+  ): Future[QLContext] = {
+    // TODO: for the moment, we're only coping with the final resulting Context here. That is
+    // *usually* what you want, but certainly more restrictive than the official semantics of QL.
+    // Figure out how to make the callers of this cope with Seq[Future[QLContext]] (or Future[Seq[QLContext]]),
+    // and adjust this to produce that.
+    processExpAll(exp, context, isParam).map { contexts =>
+      if (contexts.isEmpty)
+        // This probably means that the expression was completely empty -- for example, an
+        // empty parameter. So we treat this as simply empty.
+        context.next(EmptyValue.untyped)
+      else
+        contexts.last
+    }
+  }
+
+  /**
+   * Wraps the given function in a new scope, which will get popped once the operation completes.
+   */
+  def withScope(
+    contextIn: QLContext,
+    f: QLContext => Future[QLContext]
+  ): Future[QLContext] = {
+    val newScopes = contextIn.scopes.get(this).getOrElse(QLScopes()).push
+    val allScopes = contextIn.scopes + (this -> newScopes)
+    val context = contextIn.copy(scopes = allScopes)(contextIn.state, contextIn.ecology)
+    f(context).map { contextOut =>
+      contextOut.withScopes(this, contextOut.scopes(this).pop)
+    }
+  }
+
+  def processExpAsScope(
+    exp: QLExp,
+    context: QLContext
+  ): Future[QLContext] = {
+    withScope(context, processExp(exp, _))
+  }
+
+  // Note that the returned Future here is guaranteed to be successful -- Exceptions are already rendered.
+  def contextsToWikitext(
+    contextsFut: Future[Seq[QLContext]],
+    insertNewlines: Boolean = false
+  ): Future[Wikitext] = {
+    // Wikify each of them:
+    val wikified = contextsFut.flatMap { contexts =>
+      Future.sequence(contexts.map(context => context.value.wikify(context.parent)))
+    }
+    // And merge them together:
+    wikified
+      .map { contexts => (Wikitext("") /: contexts)(_.+(_, insertNewlines)) }
+      // Iff the Future contains an Exception, render that here. This is how we display errors in-place,
+      // instead of having them propagate out to overwhelm the page:
+      .recoverWith {
+        case ex: PublicException =>
+          warningFut(initialContext, ex.display(initialContext.requestOpt)).flatMap(_.value.wikify(initialContext))
+      }
+  }
+
+}

--- a/querki/scalajvm/app/querki/ql/QLProfilers.scala
+++ b/querki/scalajvm/app/querki/ql/QLProfilers.scala
@@ -1,0 +1,20 @@
+package querki.ql
+
+import querki.ecology.EcologyMember
+import querki.globals.Ecology
+
+/**
+ * This is created by and obtained from the QLEcot:
+ */
+private[ql] class QLProfilers(implicit val ecology: Ecology) extends EcologyMember {
+  lazy val Profiler = interface[querki.tools.Profiler]
+
+  lazy val parse = Profiler.createHandle("QLParser.parse")
+  lazy val processMethod = Profiler.createHandle("QLParser.processMethod")
+  lazy val processCall = Profiler.createHandle("QLParser.processCall")
+  lazy val processTextStage = Profiler.createHandle("QLParser.processTextStage")
+  lazy val processNumber = Profiler.createHandle("QLParser.processNumber")
+  lazy val processCallDetail = Profiler.createHandle("QLParser.call")
+  lazy val processThing = Profiler.createHandle("QLParser.processThing")
+  lazy val wikify = Profiler.createHandle("QLParser.wikify")
+}

--- a/querki/scalajvm/app/querki/ql/QLScopes.scala
+++ b/querki/scalajvm/app/querki/ql/QLScopes.scala
@@ -1,0 +1,29 @@
+package querki.ql
+
+import querki.values.QValue
+
+case class QLScope(bindings: Map[String, QValue] = Map.empty) {
+  def bind(pair: (String, QValue)) = copy(bindings = bindings + pair)
+  def lookup(name: String) = bindings.get(name)
+}
+
+case class QLScopes(scopes: List[QLScope] = List.empty) {
+
+  // Add the specified binding to the current scope:
+  def bind(pair: (String, QValue)) = {
+    val newScopes = (scopes.head.bind(pair)) :: scopes.tail
+    copy(scopes = newScopes)
+  }
+
+  def lookup(name: String): Option[QValue] = {
+    (Option.empty[QValue] /: scopes) { (result, scope) =>
+      result match {
+        case Some(r) => result
+        case None    => scope.lookup(name)
+      }
+    }
+  }
+
+  def push = copy(scopes = QLScope() :: scopes)
+  def pop = copy(scopes = scopes.tail)
+}

--- a/querki/scalajvm/app/querki/ql/package.scala
+++ b/querki/scalajvm/app/querki/ql/package.scala
@@ -2,7 +2,7 @@ package querki
 
 import querki.globals._
 
-import models.{Collection, Property, PropertyBundle, PType, PTypeBuilder, Thing, Wikitext}
+import models.{Collection, PType, PTypeBuilder, Property, PropertyBundle, Thing, Wikitext}
 
 import querki.basic.PlainText
 import querki.core.QLText
@@ -14,10 +14,10 @@ package object ql {
 
   /**
    * This trait should be used by any type that can consider itself "code" -- in particular, that wants to be
-   * displayable in the _code() method. 
+   * displayable in the _code() method.
    */
   trait CodeType {
-    def code(elem:ElemValue):String
+    def code(elem: ElemValue): String
   }
 
   /**
@@ -26,94 +26,108 @@ package object ql {
    * when a method returns a partially-applied function.
    */
   trait QLFunction {
-    def qlApplyTop(inv:Invocation, transformThing:Thing):Future[QLContext]
+
+    def qlApplyTop(
+      inv: Invocation,
+      transformThing: Thing
+    ): Future[QLContext]
   }
-  
+
   /**
    * This quietly transforms a returned InvocationValue[QValue] into a QValue, and will typically be
    * invoked at the end of the function.
    */
-  implicit def inv2QValue(inv:InvocationValue[QValue])(implicit ecology:Ecology):QFut = {
+  implicit def inv2QValue(inv: InvocationValue[QValue])(implicit ecology: Ecology): QFut = {
     ecology.api[querki.ql.QL].inv2QValueImpl(inv)
   }
-  
+
   trait WithFilter[T] {
-    def map[R](mf:T => R):InvocationValue[R]
-    def flatMap[R](mf:T => InvocationValue[R]):InvocationValue[R]
-    def withFilter(g:T => Boolean):WithFilter[T]
+    def map[R](mf: T => R): InvocationValue[R]
+    def flatMap[R](mf: T => InvocationValue[R]): InvocationValue[R]
+    def withFilter(g: T => Boolean): WithFilter[T]
   }
-  
+
   /**
    * The InvocationValue Monad, which is how we query Invocations inside of a for.
    */
   trait InvocationValue[T] {
-    def inv:Invocation
-    
-    def map[R](f:T => R):InvocationValue[R]
-    def flatMap[R](f:T => InvocationValue[R]):InvocationValue[R]
-    def withFilter(f:T => Boolean):WithFilter[T]
-    
+    def inv: Invocation
+
+    def map[R](f: T => R): InvocationValue[R]
+    def flatMap[R](f: T => InvocationValue[R]): InvocationValue[R]
+    def withFilter(f: T => Boolean): WithFilter[T]
+
     // Access to the results of the computation. Most calling code should ignore this, and allow
     // inv2QValue to tie it all back together again.
-    def get:Future[Iterable[T]]
-    
+    def get: Future[Iterable[T]]
+
     /**
      * Normally, when you map over an InvocationValue, it will iterate over the results, one at a time.
      * But occasionally, you want to get *all* of the results as a lump for processing. Use .all to
      * get that.
      */
-    def all:InvocationValue[Iterable[T]]
-    
+    def all: InvocationValue[Iterable[T]]
+
     /**
      * Occasionally you really only want a single result to come out. For example, when you are generating
      * something like a label, you probably only want *one* label -- otherwise, you wind up with a multiplicative
      * explosion of results. This function restricts the results to just the first one found.
-     * 
+     *
      * If *no* results are found, then this will be empty and skipped, as usual.
      */
     def one: InvocationValue[T]
   }
-  
+
   /**
    * This encapsulates the call information about a single function invocation in QL. In general,
    * common functionality should get wrapped up into here.
    */
   trait Invocation {
+
     /**
      * Should be used by Functions that only take a single context, which should be the definingContext
      * if there is one. Returns a new Invocation that has the receivedContext and definingContext set
      * to the same value.
-     * 
+     *
      * Basically, this should be used by Functions that are members of a specific Thing, and only
      * care about that Thing.
      */
-    def preferDefiningContext:Invocation
-    
+    def preferDefiningContext: Invocation
+
     /**
      * Turns an arbitrary value into an InvocationValue, for use in a for comprehension.
      */
-    def wrap[T](v:T):InvocationValue[T]
-    
+    def wrap[T](v: T): InvocationValue[T]
+
     /**
      * Produces an InvocationValue for an error.
      */
-    def error[T](name:String, params:String*):InvocationValue[T]
-    
+    def error[T](
+      name: String,
+      params: String*
+    ): InvocationValue[T]
+
     /**
      * Wraps a Future into Invocation-speak.
      */
-    def fut[T](fut:Future[T]):InvocationValue[T]
-    
+    def fut[T](fut: Future[T]): InvocationValue[T]
+
     /**
      * Turns an Option value into an InvocationValue, so they can be used in a for comprehension together.
      */
-    def opt[T](opt:Option[T], errOpt:Option[PublicException] = None):InvocationValue[T]
-    
+    def opt[T](
+      opt: Option[T],
+      errOpt: Option[PublicException] = None
+    ): InvocationValue[T]
+
     /**
      * Turns an Iterable into an InvocationValue, so they can be used in a for comprehension together.
      */
-    def iter[T](it:Iterable[T], errOpt:Option[PublicException] = None):InvocationValue[T]
-    
+    def iter[T](
+      it: Iterable[T],
+      errOpt: Option[PublicException] = None
+    ): InvocationValue[T]
+
     /**
      * Test the situation. This is essentially a runtime assertion, and can be used to check that the
      * user's code is correctly formed. The predicate should normally return true. If it does *not* return
@@ -121,344 +135,418 @@ package object ql {
      * (which should be registered in the messages file) with the given params. Params is intentionally done
      * as a callback, for efficiency's sake.
      */
-    def test(predicate: => Boolean, errorName:String, params: => Seq[Any]):InvocationValue[Boolean]
-    
+    def test(
+      predicate: => Boolean,
+      errorName: String,
+      params: => Seq[Any]
+    ): InvocationValue[Boolean]
+
     /**
      * Declares the return type for the expected result. This can occasionally be crucial in order to
      * cast an empty return collection to the right type. It is strongly recommended if this function
      * can return an empty collection and you know the desired Type.
-     * 
+     *
      * This returns a dummy Boolean, but that is simply to make the for comprehension work -- just assign
      * it to a dummy binding and otherwise ignore the result. (It turns out that returning Unit causes
      * things to short-circuit.)
      */
-    def returnsType(pt:PType[_]):InvocationValue[Boolean]
-    
+    def returnsType(pt: PType[_]): InvocationValue[Boolean]
+
     /**
      * Says what Collection is expected from this invocation.
-     * 
+     *
      * By the nature of the way Querki Collections work, it is tricky to automatically suss this correctly;
      * there is a tendency for QValues to wind up as ExactlyOne if they only contain one element. This method
      * allows the Function to declare that, no really, we want this to produce a List.
-     * 
+     *
      * In theory, we might be able to make this more automated, but attempts to do so have so far tended to
      * have unfortunate side-effects. So for now, we're taking this conservative approach.
      */
-    def preferCollection(coll:Collection):InvocationValue[Boolean]
-    
+    def preferCollection(coll: Collection): InvocationValue[Boolean]
+
     /**
      * The simplest accessor -- simply returns the received value (context.v), unmodified. Mostly sugar for
      * wrapping that in an InvocationValue.
      */
-    def contextValue:InvocationValue[QValue]
+    def contextValue: InvocationValue[QValue]
 
     /**
      * If the context's value is of the specified type (which need not be a PType), return
      * it cast to that type.
      */
-    def contextTypeAs[T : scala.reflect.ClassTag]:InvocationValue[T]
+    def contextTypeAs[T : scala.reflect.ClassTag]: InvocationValue[T]
 
     /**
      * This iterates over the individual elements of the received context, wrapping each one as a
      * context unto itself to make it usable.
      */
-    def contextElements:InvocationValue[QLContext]
-    
+    def contextElements: InvocationValue[QLContext]
+
     /**
      * Iterates over all of the elements in the received context.
-     * 
+     *
      * This should generally be used in preference to contextFirstAs -- it is more general and
      * "Querkish".
      */
-    def contextAllAs[VT](pt:PType[VT]):InvocationValue[VT]
-    
+    def contextAllAs[VT](pt: PType[VT]): InvocationValue[VT]
+
     /**
      * If the received context is of the specified type, returns the first element of that context
      * monadically.
-     * 
+     *
      * In general, try to avoid this method, in favor of contextAllAs instead.
      */
-    def contextFirstAs[VT](pt:PType[VT]):InvocationValue[VT]
-    
+    def contextFirstAs[VT](pt: PType[VT]): InvocationValue[VT]
+
     /**
      * Iterates over all of the received Things. (That is, this checks that the received values are
      * all LinkType, resolves them to Thing, and gives an error if any aren't Links.)
      */
-    def contextAllThings:InvocationValue[Thing] = contextAllThings(context)
+    def contextAllThings: InvocationValue[Thing] = contextAllThings(context)
 
     /**
      * This overload of contextAllThings lets you say which context to use. It should usually be
      * used underneath contextElements.
      */
-    def contextAllThings(processContext:QLContext):InvocationValue[Thing]
-    
+    def contextAllThings(processContext: QLContext): InvocationValue[Thing]
+
     /**
      * Iterates over all of the received Bundles. That is, you can pass *either* a Link to a Thing or a
      * ModeledPropertyBundle into here, and the rest of the code can deal with it.
      */
-    def contextAllBundles:InvocationValue[PropertyBundle]
-    
+    def contextAllBundles: InvocationValue[PropertyBundle]
+
     /**
      * Similar to contextAllBundles, but this provides you with the Context as well.
-     * 
+     *
      * Note that bundlesAndContextsForProp is *usually* more correct. Only use this when you aren't
      * resolving a real Property. (For example, _edit, which syntactically looks like a Method, but
      * really isn't.)
      */
-    def contextBundlesAndContexts:InvocationValue[(PropertyBundle, QLContext)]
-    
+    def contextBundlesAndContexts: InvocationValue[(PropertyBundle, QLContext)]
+
     /**
      * Given a Property that we have invoked, find the likeliest thing to invoke it *on*.
-     * 
+     *
      * Conceptually, this is a bit too powerful to go here, but we need to invoke it from several different places.
      */
-    def bundlesAndContextsForProp(prop:Property[_,_]):InvocationValue[(PropertyBundle, QLContext)]
-    
+    def bundlesAndContextsForProp(prop: Property[_, _]): InvocationValue[(PropertyBundle, QLContext)]
+
     /**
      * Returns the first Thing in the received context.
-     * 
+     *
      * In general, try to avoid this method, in favor of contextAllThings instead.
      */
-    def contextFirstThing:InvocationValue[Thing]
-    
+    def contextFirstThing: InvocationValue[Thing]
+
     /**
      * Expects that the definingContext is a Property, and returns that.
      */
-    def definingContextAsProperty:InvocationValue[Property[_,_]]
-    
+    def definingContextAsProperty: InvocationValue[Property[_, _]]
+
     /**
      * This is a bit specialized, but expects that the defining (dotted) context will be a Property
      * of the specified Type.
-     * 
+     *
      * Future-proofing note: while QL syntax currently only allows a single value in this position,
      * this is written to iterate over all values found. This may become relevant as bindings become
      * more powerful in the QL language.
      */
-    def definingContextAsPropertyOf[VT](targetType:PType[VT]):InvocationValue[Property[VT,_]]
-    
-    def definingContextAsOptionalPropertyOf[VT](targetType:PType[VT]):InvocationValue[Option[Property[VT,_]]]
-    
+    def definingContextAsPropertyOf[VT](targetType: PType[VT]): InvocationValue[Property[VT, _]]
+
+    def definingContextAsOptionalPropertyOf[VT](targetType: PType[VT]): InvocationValue[Option[Property[VT, _]]]
+
     /**
      * Process and return the specific parameter, assuming nothing about the results.
      */
-    def process(name:String, processContext:QLContext = context):InvocationValue[QValue]
-    
+    def process(
+      name: String,
+      processContext: QLContext = context
+    ): InvocationValue[QValue]
+
     /**
      * Get the specified parameter's values, which should be of the given Type.
      */
-    def processAs[VT](name:String, pt:PType[VT], processContext:QLContext = context):InvocationValue[VT]
-    
+    def processAs[VT](
+      name: String,
+      pt: PType[VT],
+      processContext: QLContext = context
+    ): InvocationValue[VT]
+
     /**
      * Given the named parameter, which should be optional and have a default of Core.QNone, returns
      * an option of the actual value. This is how you typically deal with an optional parameter where
      * the "empty" behavior is different from the "full", so you don't just want to set a default.
      */
-    def processAsOpt[VT](name:String, pt:PType[VT], processContext:QLContext = context):InvocationValue[Option[VT]]
-    
+    def processAsOpt[VT](
+      name: String,
+      pt: PType[VT],
+      processContext: QLContext = context
+    ): InvocationValue[Option[VT]]
+
     /**
      * Whereas normal processAs returns each of the matched elements one at a time, this returns *all* of them
      * as a List.
      */
-    def processAsList[VT](name:String, pt:PType[VT], processContext:QLContext = context):InvocationValue[List[VT]]
-    
+    def processAsList[VT](
+      name: String,
+      pt: PType[VT],
+      processContext: QLContext = context
+    ): InvocationValue[List[VT]]
+
     /**
      * Returns the numbered parameter if it exists, in raw parse-tree form. You only use this for "meta" functions that
      * are operating at the syntactic level, which aren't simply processing the parameter as usual.
      */
-    def rawParam(name:String):InvocationValue[Option[QLExp]]
-    
+    def rawParam(name: String): InvocationValue[Option[QLExp]]
+
     /**
      * Similar to rawParam(), but produces an error if the parameter is not found.
      */
-    def rawRequiredParam(name:String):InvocationValue[QLExp]
-    
-    /**
-     * DEPRECATED
-     * 
-     * Process and return the specific parameter, assuming nothing about the results.
-     */
-    def processParam(paramNum:Int, processContext:QLContext = context):InvocationValue[QValue]
+    def rawRequiredParam(name: String): InvocationValue[QLExp]
 
     /**
      * DEPRECATED
-     * 
+     *
+     * Process and return the specific parameter, assuming nothing about the results.
+     */
+    def processParam(
+      paramNum: Int,
+      processContext: QLContext = context
+    ): InvocationValue[QValue]
+
+    /**
+     * DEPRECATED
+     *
      * Get the specified parameter's first value, which should be of the given Type.
      */
-    def processParamFirstAs[VT](paramNum:Int, pt:PType[VT], processContext:QLContext = context):InvocationValue[VT]
-    
+    def processParamFirstAs[VT](
+      paramNum: Int,
+      pt: PType[VT],
+      processContext: QLContext = context
+    ): InvocationValue[VT]
+
     /**
      * Variation of processParamFirstAs, which copes with optional parameters and lets you define a default.
-     * 
+     *
      * IMPORTANT: if the actual parameter results in an empty value, the default is returned. That is, an empty
      * evaluation of the parameter is considered to be equivalent to the parameter not being specified in the
-     * first place. This is crucial so that _filter() works with expressions that are sometimes empty. 
-     * 
+     * first place. This is crucial so that _filter() works with expressions that are sometimes empty.
+     *
      * TODO: this should mostly go away as we switch to proper signature definitions, and named parameters. But
      * it is still used in a few unconventional situations.
      */
-    def processParamFirstOr[VT](paramNum:Int, pt:PType[VT], default:VT, processContext:QLContext = context):InvocationValue[VT]
-    
+    def processParamFirstOr[VT](
+      paramNum: Int,
+      pt: PType[VT],
+      default: VT,
+      processContext: QLContext = context
+    ): InvocationValue[VT]
+
     /**
      * The general case for Functions that may take their first value as either an explicit parameter or
      * as the context.
-     * 
+     *
      * IMPORTANT: paramNum is the *index* of the parameter, expectedParams is the expected *length*. So
      * firstParamOrContextValue, for a single-parameter Function, is equivalent to
      * processParamNofM(0, 1).
-     * 
+     *
      * Produces an error if the actual number of params is less than (expectedParams - 1).
      */
-    def processParamNofM(paramNum:Int, expectedParams:Int, processContext:QLContext = context):InvocationValue[QValue]
-    
+    def processParamNofM(
+      paramNum: Int,
+      expectedParams: Int,
+      processContext: QLContext = context
+    ): InvocationValue[QValue]
+
     /**
      * DEPRECATED
-     * 
+     *
      * Returns the numbered parameter if it exists, in raw parse-tree form. You only use this for "meta" functions that
      * are operating at the syntactic level, which aren't simply processing the parameter as usual.
      */
-    def rawParam(paramNum:Int):InvocationValue[QLExp]
-    
+    def rawParam(paramNum: Int): InvocationValue[QLExp]
+
     //////////////
     //
     // These are the raw fields. By and large, you should prefer *not* to use these, and some of them
     // may go away in the long run. If possible, use higher-level functions instead.
     //
-    
+
     /**
      * The "primary" context of this invocation. This is an exact synonym for receivedContext, and is the
-     * one you usually care about. 
+     * one you usually care about.
      */
-    def context:QLContext
-    
+    def context: QLContext
+
     /**
      * The SpaceState of the Context.
-     * 
+     *
      * IMPORTANT: if the "_space" parameter is provided to this Invocation, that Space will be used instead.
      * It can be the context's Space, or one of its Apps.
      */
-    def state:SpaceState
-    
+    def state: SpaceState
+
     /**
      * The Context that was passed to this function. This always exists, although a few functions don't care
      * about it.
      */
-    def receivedContext:QLContext
-    
+    def receivedContext: QLContext
+
     /**
      * The Context that this function was defined on, which may be different from the received one.
      */
-    def definingContext:Option[QLContext]
-    
+    def definingContext: Option[QLContext]
+
     /**
      * The Thing that this QL expression was defined in.
      */
-    def lexicalThing:Option[PropertyBundle]
-    
+    def lexicalThing: Option[PropertyBundle]
+
     /**
      * How many parameters were actually given?
      */
-    def numParams:Int
-    
+    def numParams: Int
+
     /**
      * The parameter list for this invocation, iff there was one.
      */
-    def paramsOpt:Option[Seq[QLParam]]
+    def paramsOpt: Option[Seq[QLParam]]
   }
-  
-  trait QL extends EcologyInterface {        
+
+  trait QL extends EcologyInterface {
+
     /**
      * Internal method, usually invoked implicitly by inv2QValue.
      */
-    def inv2QValueImpl(inv:InvocationValue[QValue]):QFut
-    
+    def inv2QValueImpl(inv: InvocationValue[QValue]): QFut
+
     /**
-     * The guts of inv2QValueImpl, which is occasionally useful for relatively low-level power functions. 
+     * The guts of inv2QValueImpl, which is occasionally useful for relatively low-level power functions.
      */
-    def collectQVs(qvs:Iterable[QValue], returnType:Option[PType[_]], preferredColl:Option[Collection]):QValue
-    
+    def collectQVs(
+      qvs: Iterable[QValue],
+      returnType: Option[PType[_]],
+      preferredColl: Option[Collection]
+    ): QValue
+
     /**
      * The primary entry point for processing a body of QLText into Wikitext.
-     * 
+     *
      * The input text should be a block of QLText (with the text on the "outside"). This parses
      * that, uses the given context and params to process it, and returns the resulting Wikitext.
      */
-    def process(input:QLText, ci:QLContext, invOpt:Option[Invocation] = None, 
-        lexicalThing:Option[PropertyBundle] = None, lexicalProp:Option[AnyProp] = None):Future[Wikitext]
-    
+    def process(
+      input: QLText,
+      ci: QLContext,
+      invOpt: Option[Invocation] = None,
+      lexicalThing: Option[PropertyBundle] = None,
+      lexicalProp: Option[AnyProp] = None
+    ): Future[Wikitext]
+
     /**
      * Process a QL Function into a QValue.
-     * 
+     *
      * The input text should be a block of QL (with any text on the "inside"). This parses that,
      * uses the given context and params to process it, and returns the resulting QValue.
-     * 
+     *
      * IMPORTANT: by its nature, this one only returns *one* QValue, from the last phrase. This should eventually become
      * a Seq of them instead.
      */
-    def processMethod(input:QLText, ci:QLContext, invOpt:Option[Invocation] = None, 
-        lexicalThing:Option[PropertyBundle] = None, lexicalProp:Option[AnyProp] = None):Future[QValue]
-    
+    def processMethod(
+      input: QLText,
+      ci: QLContext,
+      invOpt: Option[Invocation] = None,
+      lexicalThing: Option[PropertyBundle] = None,
+      lexicalProp: Option[AnyProp] = None
+    ): Future[QValue]
+
     /**
      * Process a QL Function all the way to Wikitext.
-     * 
+     *
      * Note that this version copes with the entire Expression, not just the last phrase.
      */
-    def processMethodToWikitext(input:QLText, ci:QLContext, invOpt:Option[Invocation] = None, 
-        lexicalThing:Option[PropertyBundle] = None, lexicalProp:Option[AnyProp] = None,
-        initialBindings:Option[Map[String, QValue]] = None):Future[Wikitext] 
-        
+    def processMethodToWikitext(
+      input: QLText,
+      ci: QLContext,
+      invOpt: Option[Invocation] = None,
+      lexicalThing: Option[PropertyBundle] = None,
+      lexicalProp: Option[AnyProp] = None,
+      initialBindings: Option[Map[String, QValue]] = None
+    ): Future[Wikitext]
+
+    /**
+     * Process an already-parsed QLExp and get the result.
+     *
+     * This is closely related to [[processMethod()]], but is available for cases where you have previously parsed
+     * the expression, and want to get on with it from there.
+     */
+    def processExp(
+      ci: QLContext,
+      exp: QLExp,
+      invOpt: Option[Invocation] = None,
+      parserOpt: Option[QLParser] = None,
+      initialBindings: Option[Map[String, QValue]] = None
+    ): Future[QLContext]
+
     /**
      * Just parses the given text, with no further processing.
-     * 
+     *
      * This is semi-internal, and relates to the incestuous relationship between QLParser
      * and QLContext.
      */
-    def parseMethod(input:String):Option[QLPhrase]
-    
+    def parseMethod(input: String): Option[QLPhrase]
+
     /**
      * Serializes the environment of the given Invocation. Intended for uses like
      * _QLButton(), where we need to be push the environment over to the Client,
      * and have it returned again.
-     * 
+     *
      * The result is an opaque String, not intended for introspection.
      */
-    def serializeContext(inv:Invocation, qlParamNameOpt:Option[String]):InvocationValue[String]
+    def serializeContext(
+      inv: Invocation,
+      qlParamNameOpt: Option[String]
+    ): InvocationValue[String]
+
     /**
      * Deserializes the block from serializeContext, into the fields needed to pass into
      * processMethodToWikitext().
      */
-    def deserializeContext(str:String)(implicit state:SpaceState):(QValue, Map[String, QValue])
-    
-    def UnknownNameType:PType[String] with PTypeBuilder[String,String]
-    def ParsedTextType:PType[Wikitext] with PTypeBuilder[Wikitext,Wikitext]
-    def ErrorTextType:PType[PlainText] with PTypeBuilder[PlainText,String]
-    def ClosureType:PType[QLClosure] with PTypeBuilder[QLClosure,QLClosure]
-    
-    def WarningValue(msg:String):QValue
-    def ErrorValue(msg:String):QValue
-    def WikitextValue(wikitext:Wikitext):QValue
-    
-    def WarningFut(msg:String):Future[QValue] = Future.successful(WarningValue(msg))
-    
-    def EmptyListCut():QValue
+    def deserializeContext(str: String)(implicit state: SpaceState): (QValue, Map[String, QValue])
+
+    def UnknownNameType: PType[String] with PTypeBuilder[String, String]
+    def ParsedTextType: PType[Wikitext] with PTypeBuilder[Wikitext, Wikitext]
+    def ErrorTextType: PType[PlainText] with PTypeBuilder[PlainText, String]
+    def ClosureType: PType[QLClosure] with PTypeBuilder[QLClosure, QLClosure]
+
+    def WarningValue(msg: String): QValue
+    def ErrorValue(msg: String): QValue
+    def WikitextValue(wikitext: Wikitext): QValue
+
+    def WarningFut(msg: String): Future[QValue] = Future.successful(WarningValue(msg))
+
+    def EmptyListCut(): QValue
   }
 
   /**
    * The various bits and pieces involved in defining formal function signatures.
    */
   trait Signature extends EcologyInterface {
+
     /**
      * A marker that should only be used in Signatures, which means "any Type can go here". If used in
      * returns, means "the same Type that was received".
      */
-    def AnyType:PType[Unit]
-    
+    def AnyType: PType[Unit]
+
     /**
      * The main point of Signature: lets you define the signature -- that is, the expected parameters -- of an InternalMethod.
      * Actually generates a SignatureProp entry, but you usually don't need to worry about that.
-     * 
+     *
      * In theory, every InternalMethod should use Signature. In practice, we're not going to be hard-assed about
      * that yet, but new ones should use it.
-     * 
+     *
      * @param expected Description of what is expected, and the PTypes that this Function accepts. If empty, it accepts *all* PTypes.
      *   If the received context is ignored, this should be set to None.
      * @param reqs The required parameters for this Function, in order.
@@ -470,11 +558,11 @@ package object ql {
      *   not use the defining context, leave this as None.
      */
     def apply(
-      expected:Option[(Seq[PType[_]], String)] = None,
-      reqs:Seq[(String, PType[_], String)] = Seq.empty,
-      opts:Seq[(String, PType[_], QValue, String)] = Seq.empty,
-      returns:(PType[_], String) = (AnyType, ""),
-      defining:Option[(Boolean, Seq[PType[_]], String)] = None
-    ):(OID, QValue)
+      expected: Option[(Seq[PType[_]], String)] = None,
+      reqs: Seq[(String, PType[_], String)] = Seq.empty,
+      opts: Seq[(String, PType[_], QValue, String)] = Seq.empty,
+      returns: (PType[_], String) = (AnyType, ""),
+      defining: Option[(Boolean, Seq[PType[_]], String)] = None
+    ): (OID, QValue)
   }
 }

--- a/querki/scalajvm/app/querki/values/Context.scala
+++ b/querki/scalajvm/app/querki/values/Context.scala
@@ -2,22 +2,23 @@ package querki.values
 
 import models._
 import com.github.nscala_time.time.Imports.DateTime
-
 import querki.ecology._
+import querki.ql.QLProcessor
 
 // TODO: this is a bad smell! Can we hide the parser better behind the Context?
-import querki.ql.{QLCall, QLPhrase, QLParser, QLScopes}
+import querki.ql.{QLCall, QLParser, QLPhrase, QLScopes}
 import querki.util.DebugRenderable
 
 /**
  * These are rather ad-hoc flags, allowing the caller of a process to pass them way down through the system.
- * 
+ *
  * Set one of these in a context by calling .withFlag() on it. Keep in mind that all children of that
  * context will have that flag. (Which is kind of the point.)
- * 
+ *
  * In a happier world, these would be handled as Reader and Writer effects. 20/20 hindsight is a lovely thing.
  */
 sealed trait ContextFlag
+
 /**
  * If set, all Links rendered under this context will be render as full, explicit <a> tags in HtmlWikitext,
  * instead of the usual [display](url) format. This should be used only if we expect the reader to be
@@ -25,52 +26,63 @@ sealed trait ContextFlag
  */
 case object ShowLinksAsFullAnchors extends ContextFlag
 
-case class QLContext(value:QValue, requestOpt:Option[RequestContext], endTime: DateTime,
-                     parentOpt:Option[QLContext] = None,
-                     parser:Option[QLParser] = None, depth:Int = 0, useCollStack:Int = 0, propOpt:Option[Property[_,_]] = None,
-                     currentValue:Option[DisplayPropVal] = None, 
-                     fromTransformOpt:Option[Thing] = None, withCallOpt:Option[QLCall] = None,
-                     scopes:Map[QLParser,QLScopes] = Map.empty, flags: Set[ContextFlag] = Set.empty)
-                     (implicit val state:SpaceState, val ecology:Ecology)
-  extends DebugRenderable with EcologyMember
-{
+case class QLContext(
+  value: QValue,
+  requestOpt: Option[RequestContext],
+  endTime: DateTime,
+  parentOpt: Option[QLContext] = None,
+  parser: Option[QLParser] = None,
+  depth: Int = 0,
+  useCollStack: Int = 0,
+  propOpt: Option[Property[_, _]] = None,
+  currentValue: Option[DisplayPropVal] = None,
+  fromTransformOpt: Option[Thing] = None,
+  withCallOpt: Option[QLCall] = None,
+  scopes: Map[QLProcessor, QLScopes] = Map.empty,
+  flags: Set[ContextFlag] = Set.empty
+)(implicit
+  val state: SpaceState,
+  val ecology: Ecology
+) extends DebugRenderable
+     with EcologyMember {
   lazy val Core = interface[querki.core.Core]
   lazy val QL = interface[querki.ql.QL]
-  
+
   def ExactlyOne = Core.ExactlyOne
   def Optional = Core.Optional
   def QList = Core.QList
-  
+
   // This might become a config param -- it is the maximum depth we will allow a call to be. For now, we're
   // keeping it very tight, but it might eventually need to be over a thousand.
   val maxDepth = 100
-  
+
   // Note that this will crash if we don't have a RequestContext!
   lazy val System = interface[querki.system.System]
-  
-  def request:RequestContext = {
+
+  def request: RequestContext = {
     requestOpt match {
       case Some(r) => r
-      case None => throw new Exception("Attempting to fetch the RequestContext from a Context that doesn't have one!")
+      case None    => throw new Exception("Attempting to fetch the RequestContext from a Context that doesn't have one!")
     }
   }
   def isEmpty = value.isEmpty
+
   // Parent matters at rendering time -- we render the final context in the context of its parent.
   // This matter most when (as often), the last context is a Text; it needs to be rendered correctly
   // in its parent context.
   // Note that, if this Context is the root, we just use it as the "parent". Be careful of possible loops!
   // You can not simply walk up this tree!
-  def parent:QLContext = {
+  def parent: QLContext = {
     parentOpt match {
       case Some(p) => p
-      case None => this
+      case None    => this
     }
   }
 
   /**
    * Take a bunch of result contexts, concatenate them, and return them as the "next".
    */
-  def concat(contexts:Iterable[QLContext]):QLContext = {
+  def concat(contexts: Iterable[QLContext]): QLContext = {
     contexts.headOption match {
       case Some(headContext) => {
         val resultType = headContext.value.pType
@@ -81,60 +93,63 @@ case class QLContext(value:QValue, requestOpt:Option[RequestContext], endTime: D
       // TODO: This isn't right: we really want the pType of what these would have contained. So this
       // function may not be at quite the right level?
       case _ => next(Core.emptyOpt(value.pType))
-    }    
+    }
   }
-  
+
   /**
    * Maps the given function to each element in this context.
-   * 
+   *
    * IMPORTANT: if the useCollection flag is set for this context, then this calls the function only once,
    * with the collection context, *not* with each element! In other words, the definition of "map" depends
    * on the useCollection flag!
    */
-  def map[T](cb:QLContext => T) = {
+  def map[T](cb: QLContext => T) = {
     if (useCollection) {
       List(cb(this))
     } else {
-      value.cv map { elem =>
+      value.cv.map { elem =>
         val elemContext = next(ExactlyOne(elem)).clearAsCollection
         cb(elemContext)
       }
     }
   }
-  
+
   /**
    * Maps the given function to each element in this context, and flattens the result.
-   * 
+   *
    * IMPORTANT: if the useCollection flag is set for this context, then this calls the function only once,
    * with the collection context, *not* with each element! In other words, the definition of "map" depends
    * on the useCollection flag!
    */
-  def mapOpt[T](cb:QLContext => Option[T]) = {
+  def mapOpt[T](cb: QLContext => Option[T]) = {
     if (useCollection) {
       val ret = cb(this)
       ret match {
         case Some(t) => List(t)
-        case None => List.empty[T]
+        case None    => List.empty[T]
       }
     } else {
-      value.cv flatMap { elem =>
+      value.cv.flatMap { elem =>
         val elemContext = next(ExactlyOne(elem)).clearAsCollection
         cb(elemContext)
       }
     }
   }
-  
+
   /**
    * Similar to ordinary map(), but produces a new Context with the result.
-   * 
+   *
    * TODO: this is fundamentally suspicious. What if ct is ExactlyOne, and cb returns None? We'll
    * wind up with an empty ExactlyOne, which violates the invariants. See collect, below, for a
    * more sensible approach.
-   * 
+   *
    * TODO: with the extremely rare exception of cases where we genuinely care about the useCollection
    * flag, this is now obviated by the various functions in Invocation. Can we get rid of it?
    */
-  def flatMapAsContext[T <: ElemValue](cb:QLContext => Option[T], resultType:PType[_]):QLContext = {
+  def flatMapAsContext[T <: ElemValue](
+    cb: QLContext => Option[T],
+    resultType: PType[_]
+  ): QLContext = {
     val ct = value.cType
     // TODO: this is an unfortunate cast. It's correct, but ick. Can we eliminate it?
     val raw = mapOpt(cb).asInstanceOf[ct.implType]
@@ -145,14 +160,14 @@ case class QLContext(value:QValue, requestOpt:Option[RequestContext], endTime: D
   /**
    * Given a function that takes a single-element context and produces a QValue, this runs that
    * over all of the elements in this context, and collects the results into a single QValue.
-   * 
+   *
    * This needs the PType of the expected result, so that it can set the results up correctly
    * if they are empty.
-   * 
+   *
    * Note that we try to return the same Collection as the incoming, but deliberately don't try
    * if the results of the function return the wrong ordinal amount.
    */
-  def collect(pt:PType[_])(cb:QLContext => QValue):QValue = {
+  def collect(pt: PType[_])(cb: QLContext => QValue): QValue = {
     if (isEmpty) {
       EmptyValue(pt)
     } else {
@@ -160,8 +175,8 @@ case class QLContext(value:QValue, requestOpt:Option[RequestContext], endTime: D
       val raw = qvs.flatten(_.cv)
       if (!raw.isEmpty && (!ElemValue.matchesType(raw.head.pType, pt))) {
         raw.head.pType match {
-          case errType:IsErrorType => ExactlyOne(raw.head)
-          case _ => throw new Exception("Context.collect expected type " + pt + " but got " + raw.head.pType)
+          case errType: IsErrorType => ExactlyOne(raw.head)
+          case _                    => throw new Exception("Context.collect expected type " + pt + " but got " + raw.head.pType)
         }
       } else {
         val newCT = chooseCollection(raw)
@@ -169,130 +184,141 @@ case class QLContext(value:QValue, requestOpt:Option[RequestContext], endTime: D
       }
     }
   }
-  
-  def chooseCollection(raw:Iterable[ElemValue]):Collection = {
+
+  def chooseCollection(raw: Iterable[ElemValue]): Collection = {
     // HACK: How should this work correctly? There seems to be a general concept trying to break out.
     // In general, collect (and many of these operations) are very monadically evil, but
     // we've consciously decided to live with that.
     value.cType match {
-      case t:querki.core.CollectionCreation#ExactlyOne => {
+      case t: querki.core.CollectionCreation#ExactlyOne => {
         if (raw.isEmpty)
-          Optional 
+          Optional
         else if (raw.size == 1)
           ExactlyOne
         else
           QList
       }
-      case t:querki.core.CollectionCreation#Optional => if (raw.size > 1) QList else Optional
-      case _ => value.cType
-    }    
+      case t: querki.core.CollectionCreation#Optional => if (raw.size > 1) QList else Optional
+      case _                                          => value.cType
+    }
   }
-  
+
   override def toString = "Context(" + value + ")@" + this.hashCode()
-  
+
   def debugRender = /*"Context@" + this.hashCode() +*/ "(" + value.debugRender(this) + ")"
-  
+
   /**
    * Convenience method to build the successor to this context, in typical chained situations.
    */
-  def next(v:QValue) = copy(value = v, parentOpt = Some(this), depth = depth + 1)
-  
+  def next(v: QValue) = copy(value = v, parentOpt = Some(this), depth = depth + 1)
+
   /**
    * Variant that indicates which "transformation" (Property or Function) caused this value to be calculated.
    */
-  def nextFrom(v:QValue, transform:Thing) = 
-    copy(value = v, parentOpt = Some(this), depth = depth + 1, fromTransformOpt = Some(transform))  
-    
+  def nextFrom(
+    v: QValue,
+    transform: Thing
+  ) =
+    copy(value = v, parentOpt = Some(this), depth = depth + 1, fromTransformOpt = Some(transform))
+
   /**
    * Variant that notes which Call we are currently processing.
    */
-  def withCall(call:QLCall, transform:Thing) = copy(depth = depth + 1, withCallOpt = Some(call), fromTransformOpt = Some(transform))
-  
+  def withCall(
+    call: QLCall,
+    transform: Thing
+  ) = copy(depth = depth + 1, withCallOpt = Some(call), fromTransformOpt = Some(transform))
+
   /**
    * Access to any page parameters from the metadata.
    */
   def requestParams = request.parsedParams
-  
+
   /**
    * asCollection means "right now, evaluate the very next operation as a collection."
    */
   def asCollection = copy(parentOpt = Some(this), depth = depth + 1, useCollStack = 1)
+
   /**
    * forceAsCollection means "evaluate the operation that is contained somewhere down inside this as a collection."
    */
   def forceAsCollection = copy(parentOpt = Some(this), depth = depth + 1, useCollStack = 2)
+
   /**
    * This seems a little delicate, and it is. clearAsCollection is dealing with the tension where the
    * inner Text of this phrase:
    * {{{
    *     * ""Some header info: [[""An interior item: ____""]]""
-   * }}}    
+   * }}}
    * gets handled element-by-element, but the parameter in this:
    * {{{
    *     _section(""My header"", ""An interior item: ____"")
-   * }}}    
+   * }}}
    * is handled at the list level.
-   * 
+   *
    * Basically, forceAsCollection tells the system that the next clearAsCollection won't do it -- you have
    * to go down a second level before it actually will clear the flag.
    */
-  def clearAsCollection = copy(parentOpt = Some(this), depth = depth + 1, 
-      useCollStack = { if (useCollStack > 0) useCollStack - 1 else 0 })
+  def clearAsCollection =
+    copy(parentOpt = Some(this), depth = depth + 1, useCollStack = { if (useCollStack > 0) useCollStack - 1 else 0 })
   def useCollection = useCollStack > 0
-  
-  def forProperty(prop:Property[_,_]) = copy(parentOpt = Some(this), depth = depth + 1, propOpt = Some(prop))
-  
-  def withState(newState:SpaceState) = copy()(newState, ecology)
-  
-  def withScopes(p:QLParser, newScopes:QLScopes) = copy(scopes = scopes + (p -> newScopes))
-  
+
+  def forProperty(prop: Property[_, _]) = copy(parentOpt = Some(this), depth = depth + 1, propOpt = Some(prop))
+
+  def withState(newState: SpaceState) = copy()(newState, ecology)
+
+  def withScopes(
+    p: QLProcessor,
+    newScopes: QLScopes
+  ) = copy(scopes = scopes + (p -> newScopes))
+
   /**
    * Adds the specified flag to this pathway.
-   * 
+   *
    * We don't bother incrementing the depth for this, since it's only accessible from internals.
    */
   def withFlag(flag: ContextFlag) = copy(flags = flags + flag)
-  
+
   /**
    * The Text Property that we are currently processing. Mainly used for error reporting, currently.
    */
-  def getProp:Option[Property[_,_]] = {
+  def getProp: Option[Property[_, _]] = {
     propOpt match {
       case Some(prop) => Some(prop)
       case None => {
         parentOpt match {
           case Some(p) => parent.getProp
-          case None => None
+          case None    => None
         }
       }
     }
   }
-  
+
   /**
    * Looks up the stack to find the Property of the specified Type. Usually used to figure out where a
    * value came from.
    */
-  def fromPropertyOfType[VT](pt:PType[VT]):Option[Property[VT,_]] = {
-    def tryParent:Option[Property[VT,_]] = parentOpt.flatMap(_.fromPropertyOfType(pt))
-    
+  def fromPropertyOfType[VT](pt: PType[VT]): Option[Property[VT, _]] = {
+    def tryParent: Option[Property[VT, _]] = parentOpt.flatMap(_.fromPropertyOfType(pt))
+
     fromTransformOpt match {
-      case Some(prop:Property[_,_]) => prop.confirmType(pt).orElse(tryParent)
-      case _ => tryParent
+      case Some(prop: Property[_, _]) => prop.confirmType(pt).orElse(tryParent)
+      case _                          => tryParent
     }
   }
-  
+
   /**
    * Returns the root of the context tree. Mainly so that parameters can start again with the same root.
    */
-  def root:QLContext = {
+  def root: QLContext = {
     parentOpt match {
       case Some(p) => p.root
-      case None => this
+      case None    => this
     }
   }
-      
+
   def isCut = value.cut
-  
+
   def isError = value.pType == QL.ErrorTextType
 }
 
@@ -301,7 +327,13 @@ case class QLContext(value:QValue, requestOpt:Option[RequestContext], endTime: D
  * Play template level.
  */
 object QLRequestContext {
-  def apply(request:RequestContext)(implicit state:SpaceState, ecology:Ecology) = {
+
+  def apply(
+    request: RequestContext
+  )(implicit
+    state: SpaceState,
+    ecology: Ecology
+  ) = {
     val endTime = ecology.api[querki.time.TimeProvider].qlEndTime
     QLContext(EmptyValue.untyped, Some(request), endTime)
   }
@@ -311,11 +343,12 @@ object QLRequestContext {
  * The context to use when you know absolutely nothing, not even a RequestContext. In general, this is
  * a design bug, and should go away eventually. (We are keeping it around because it is used under the
  * hood of Thing.displayName, indirectly, which will take some work to fix.)
- * 
+ *
  * TODO: deprecate and remove this.
  */
 object EmptyContext {
-  def apply(implicit ecology:Ecology) = {
+
+  def apply(implicit ecology: Ecology) = {
     val endTime = ecology.api[querki.time.TimeProvider].qlEndTime
     QLContext(EmptyValue.untyped, None, endTime)(ecology.api[querki.system.System].State, ecology)
   }

--- a/querki/scalajvm/test/querki/history/HistoryMidTests.scala
+++ b/querki/scalajvm/test/querki/history/HistoryMidTests.scala
@@ -126,10 +126,10 @@ object HistoryMidTests {
       result <- evaluateQL(spaceId, """_listDeletedThings(render = ""[[_oid]]"") -> _commas""")
       _ = assert(result.plaintext.split(',').length == 2)
 
-      // But if we add a predicate on the Model, we only see that one:
+      // But if we add a filter on the Model, we only see that one:
       result <- evaluateQL(
         spaceId,
-        """_listDeletedThings(predicate = _model -> _is(The Model), render = ""[[_oid]]"") -> _commas"""
+        """_listDeletedThings(filter = _model -> _is(The Model), render = ""[[_oid]]"") -> _commas"""
       )
       _ = assert(result.plaintext.split(',').length == 1)
       _ = assert(secondOID == result.plaintext)

--- a/querki/scalajvm/test/querki/test/mid/ClientFuncs.scala
+++ b/querki/scalajvm/test/querki/test/mid/ClientFuncs.scala
@@ -1,21 +1,17 @@
 package querki.test.mid
 
 import scala.concurrent.Promise
-
 import upickle._
 import autowire._
-
 import play.api.mvc.{AnyContentAsFormUrlEncoded, Result, Session}
 import play.api.test._
 import play.api.test.Helpers._
-
 import controllers.ClientController
-
 import querki.api._
 import querki.data._
 import querki.globals._
-
 import AllFuncs._
+import org.scalactic.source.Position
 
 /**
  * Interface layer for making calls to the Client API. Most tests will mix this in, but you
@@ -23,49 +19,57 @@ import AllFuncs._
  */
 trait ClientFuncs {
   implicit lazy val clientFuncs = this
-  
-  lazy val querkiVersion:String = querki.BuildInfo.version
+
+  lazy val querkiVersion: String = querki.BuildInfo.version
   // TODO: we eventually want to be able to let tests populate this map, which becomes the metadata
   // sent in API calls. That is probably another variant of ClientBase?
   val currentPageParams: Map[String, String] = Map.empty
-    
+
   trait ClientBase extends autowire.Client[String, upickle.default.Reader, upickle.default.Writer] {
     implicit def session: Session
     def harness: HarnessInfo
     def callApi(req: FakeRequest[AnyContentAsFormUrlEncoded]): Future[Result]
-    
+
     implicit lazy val materializer = harness.app.materializer
     def controller = harness.controller[ClientController]
-    
+
     private val resultPromise = Promise[Result]
     val resultFut = resultPromise.future
-    
-    def sendRequest(req: Request, metadata: RequestMetadata): Future[Result] = {
+
+    def sendRequest(
+      req: Request,
+      metadata: RequestMetadata
+    ): Future[Result] = {
       val request = sessionFormRequest(
         "pickledRequest" -> write(req),
         "pickledMetadata" -> write(metadata)
       )
-      
+
       callApi(request)
     }
-    
-    def translateException(response: String, req: Request): Nothing = {
+
+    def translateException(
+      response: String,
+      req: Request
+    )(implicit
+      pos: Position
+    ): Nothing = {
       try {
         val aex = read[ApiException](response)
         throw aex
       } catch {
         // The normal case -- the server sent an ApiException, which we will propagate up
         // to the calling code:
-        case aex:querki.api.ApiException => throw aex
+        case aex: querki.api.ApiException => throw aex
         // The server sent a non-ApiException, which is unfortunate. Just display it:
-        case _:Throwable => {
+        case _: Throwable => {
           if (response.startsWith("Unexpected error."))
             throw new Exception(s"Got unexpected error from request $req")
           throw new Exception(s"Unable to parse server response $response from request $req")
         }
       }
     }
-  
+
     override def doCall(req: Request): Future[String] = {
       val metadata = RequestMetadata(querkiVersion, currentPageParams)
       for {
@@ -78,42 +82,51 @@ trait ClientFuncs {
         byteString <- result.body.consumeData
         charset = result.body.contentType match {
           case Some(s) if s.contains("charset=") => Some(s.split("; *charset=").drop(1).mkString.trim)
-          case _ => None
+          case _                                 => None
         }
         response = byteString.decodeString(charset.getOrElse("utf-8"))
-        wrapped = try {
-          read[ResponseWrapper](response)
-        } catch {
-          case t: Throwable => translateException(response, req)
-        }
+        wrapped =
+          try {
+            read[ResponseWrapper](response)
+          } catch {
+            case t: Throwable => translateException(response, req)
+          }
         // TODO: we need to do something akin to this. How do we do so from inside here, without being
         // all horribly mutable? Maybe we should be taking the current User as a parameter, and asserting
         // that in the normal case? Should the result ever change outside of login/logout?
         // UserAccess.setUser(wrapped.currentUser)
-      }
-        yield wrapped.payload
+      } yield wrapped.payload
     }
-    
-    def read[Result: upickle.default.Reader](p: String) = {
+
+    def read[Result : upickle.default.Reader](p: String) = {
       try {
         upickle.default.read[Result](p)
       } catch {
-        case ex:Exception => {
+        case ex: Exception => {
           println(s"Exception while trying to unpickle response $p: $ex")
           throw ex
         }
       }
     }
-    def write[Result: upickle.default.Writer](r: Result) = upickle.default.write(r)
+    def write[Result : upickle.default.Writer](r: Result) = upickle.default.write(r)
   }
-  
-  class NSClient(val harness: HarnessInfo, val session: Session) extends ClientBase {
+
+  class NSClient(
+    val harness: HarnessInfo,
+    val session: Session
+  ) extends ClientBase {
+
     def callApi(request: FakeRequest[AnyContentAsFormUrlEncoded]): Future[Result] = {
       call(controller.rawApiRequest(), request)
     }
   }
-  
-  class Client(val harness: HarnessInfo, spaceInfo: SpaceInfo, val session: Session) extends ClientBase {
+
+  class Client(
+    val harness: HarnessInfo,
+    spaceInfo: SpaceInfo,
+    val session: Session
+  ) extends ClientBase {
+
     def callApi(request: FakeRequest[AnyContentAsFormUrlEncoded]): Future[Result] = {
       call(controller.apiRequest(spaceInfo.ownerHandle, spaceInfo.oid.underlying), request)
     }

--- a/querki/scalajvm/test/querki/test/mid/SetupFuncs.scala
+++ b/querki/scalajvm/test/querki/test/mid/SetupFuncs.scala
@@ -6,44 +6,72 @@ import org.scalatest.Matchers._
 import querki.security.SecurityMidFuncs
 
 /**
-  * Functions that provide common setup, to reduce boilerplate for special-purpose tests.
-  */
+ * Functions that provide common setup, to reduce boilerplate for special-purpose tests.
+ */
 trait SetupFuncs {
+
   /**
-    * This creates the specified normal user, and has them create a Space.
-    *
-    * @param usernameBase The base of this user's name. This must be unique, so should be based on the suite name.
-    *                     Note that this is the display name, and may be arbitrarily long.
-    * @param spaceName The name of the Space, which only needs to be unique per-User.
-    * @return The owner of the Space, and the TID of the Space.
-    */
-  def setupUserAndSpace(usernameBase: String, spaceName: String): TestOp[TestUser] = {
+   * This creates the specified normal user, and has them create a Space.
+   *
+   * @param usernameBase The base of this user's name. This must be unique, so should be based on the suite name.
+   *                     Note that this is the display name, and may be arbitrarily long.
+   * @param spaceName The name of the Space, which only needs to be unique per-User.
+   * @return The owner of the Space, and the TID of the Space.
+   */
+  def setupUserAndSpace(
+    usernameBase: String,
+    spaceName: String
+  ): TestOp[TestUser] = {
     for {
       std <- getStd
       user = TestUser(usernameBase)
       loginResults <- newUser(user)
       space <- createSpace(spaceName)
-    }
-      yield user
+    } yield user
+  }
+
+  case class RegressionInfo(
+    owner: TestUser,
+    std: StdThings,
+    spaceId: TID
+  )
+
+  /**
+   * High-level setup function to initialize things for a typical regression test.
+   *
+   * This is purely a convenience function, but extracts the pattern that I seem to use repeatedly.
+   *
+   * @param ticketId the base OID for the ticket governing this test, like "7w4gerb"
+   */
+  def setupStandardRegressionTest(ticketId: String): TestOp[RegressionInfo] = {
+    for {
+      _ <- step(s"Regression test for QI.$ticketId")
+      std <- getStd
+      owner <- setupUserAndSpace(s"QI$ticketId Owner", s"QI$ticketId Space")
+      spaceId <- TestOp.fetch(_.curSpace.info.oid)
+    } yield RegressionInfo(owner, std, spaceId)
   }
 
   def fetchSpaceInfo(): TestOp[SpaceInfo] = TestOp.fetch(_.client.spaceOpt.get)
 
-  def inviteIntoSpace(owner:TestUser, spaceId: TID, member: TestUser): TestOp[Unit] = {
+  def inviteIntoSpace(
+    owner: TestUser,
+    spaceId: TID,
+    member: TestUser
+  ): TestOp[Unit] = {
     val doIt = for {
       _ <- ClientState.switchToUser(owner)
       // TODO: refactor this invite-to-space code into SetupFuncs:
       token <- EmailTesting.nextEmail
       inviteResponse <- SecurityMidFuncs.invite(Seq(member.email), Seq.empty)
-      _ = inviteResponse.newInvites should contain (member.display)
+      _ = inviteResponse.newInvites should contain(member.display)
       spaceInfo <- fetchSpaceInfo()
 
       _ <- ClientState.switchToUser(member)
       inviteHash <- EmailTesting.extractInviteHash(token)
       _ <- acceptInvite(inviteHash, spaceInfo)
       _ <- setClientSpace(spaceInfo)
-    }
-      yield ()
+    } yield ()
 
     ClientState.cachingUser(doIt)
   }


### PR DESCRIPTION
This is a fairly powerful new function, that allows you to examine all of the Things that have been deleted in this Space, or just a subset of them.  It also allows you to say, pretty arbitrarily, what gets returned from each of them.

There is now a standard System Deleted Things Page, hanging off of the Advanced Page, with the simple version of this functionality.

Includes a scenario test for the key functionality here.

Also includes a major refactor that I've been putting off for years now, lifting `QLProcessor` out of `QLParser`.  Fixed a lot of bugs caused by that; hopefully there aren't more, but we'll see.

This also involves a lot of reformatting, and an update to the current version of scalafmt.  Sometime soon, I'm going to need to reformat the world instead of doing this ad-hoc.