### PR TITLE
QI.7w4geta - test mass-undelete

### DIFF
--- a/querki/scalajvm/app/querki/history/SpaceHistory.scala
+++ b/querki/scalajvm/app/querki/history/SpaceHistory.scala
@@ -334,7 +334,8 @@ private[history] class SpaceHistory(
                 predicateResultFut.flatMap { passes =>
                   def justTheOID(): Future[(List[(QValue, OID)], SpaceState)] = {
                     val deleted = (ExactlyOne(LinkType(thingId)), thingId)
-                    Future.successful((deleted :: soFar, state))
+                    val filtered = soFar.filterNot(_._2 == thingId)
+                    Future.successful((deleted :: filtered, state))
                   }
 
                   if (passes) {
@@ -345,9 +346,9 @@ private[history] class SpaceHistory(
                           // Remove any *previous* deletions of this Thing -- we want to wind up with only the
                           // most recent. This is a little inefficient in Big-O terms, but I'm guessing that won't
                           // matter a lot in reality:
-                          val resultPair = (result.value, thingId)
+                          val deleted = (result.value, thingId)
                           val filtered = soFar.filterNot(_._2 == thingId)
-                          ((resultPair :: filtered, state))
+                          ((deleted :: filtered, state))
                         }.recoverWith {
                           case ex: Exception => {
                             ex.printStackTrace()

--- a/querki/scalajvm/test/querki/history/HistoryMidTests.scala
+++ b/querki/scalajvm/test/querki/history/HistoryMidTests.scala
@@ -6,6 +6,7 @@ import querki.data.TID
 import querki.test.mid._
 import AllFuncs._
 import HistoryMidFuncs._
+import org.scalactic.source.Position
 import querki.security.SecurityMidFuncs._
 import querki.test.mid.ClientState._
 
@@ -88,6 +89,7 @@ object HistoryMidTests {
     } yield oid
   }
 
+  // This is a broad scenario test for _listDeletedThings:
   lazy val test7w4gerb: TestOp[Unit] = {
     for {
       info <- setupStandardRegressionTest("7w4gerb")
@@ -100,21 +102,21 @@ object HistoryMidTests {
       third <- makeThing(model, "Third")
 
       // Initially, the list is empty:
-      result <- evaluateQL(spaceId, """_listDeletedThings(render = ""[[_oid]]"")""")
-      _ = assert(result.plaintext.isEmpty)
+      _ <- assertNumDeletedThingsIs(0)
 
       // After we delete something, it shows up:
       _ <- deleteThing(second)
+      _ <- assertNumDeletedThingsIs(1)
       result <- evaluateQL(spaceId, """_listDeletedThings(render = ""[[_oid]]"")""")
       _ = assert(secondOID == result.plaintext)
 
       // After we undelete it, it's empty again:
       _ <- evaluateQL(spaceId, s"_undeleteThing($secondOID)")
-      result <- evaluateQL(spaceId, """_listDeletedThings(render = ""[[_oid]]"")""")
-      _ = assert(result.plaintext.isEmpty)
+      _ <- assertNumDeletedThingsIs(0)
 
       // After we re-delete it, it only shows up once, not twice:
       _ <- deleteThing(second)
+      _ <- assertNumDeletedThingsIs(1)
       result <- evaluateQL(spaceId, """_listDeletedThings(render = ""[[_oid]]"")""")
       _ = assert(secondOID == result.plaintext)
 
@@ -123,8 +125,7 @@ object HistoryMidTests {
       secondFirst <- makeThing(secondModel, "Second First")
       _ <- deleteThing(secondFirst)
       // Now we should see two deleted things:
-      result <- evaluateQL(spaceId, """_listDeletedThings(render = ""[[_oid]]"") -> _commas""")
-      _ = assert(result.plaintext.split(',').length == 2)
+      _ <- assertNumDeletedThingsIs(2)
 
       // But if we add a filter on the Model, we only see that one:
       result <- evaluateQL(
@@ -133,6 +134,48 @@ object HistoryMidTests {
       )
       _ = assert(result.plaintext.split(',').length == 1)
       _ = assert(secondOID == result.plaintext)
+    } yield ()
+  }
+
+  def assertNumDeletedThingsIs(expected: Int)(implicit pos: Position): TestOp[Unit] = {
+    for {
+      spaceId <- TestOp.fetch(_.curSpace.info.oid)
+      result <- evaluateQL(spaceId, """_listDeletedThings() -> _commas""")
+      _ = assert(result.plaintext.split(',').filterNot(_.isEmpty).length == expected)
+    } yield ()
+  }
+
+  // This tests that you can feed the results of _listDeletedThings() into _undeleteThing to undelete en masse:
+  lazy val test7w4geta: TestOp[Unit] = {
+    for {
+      info <- setupStandardRegressionTest("7w4geta")
+      spaceId = info.spaceId
+
+      // Make some Things:
+      model <- makeModel("The Model")
+      first <- makeThing(model, "First")
+      second <- makeThing(model, "Second")
+      third <- makeThing(model, "Third")
+      count <- evaluateQL(spaceId, "The Model._instances -> _count").map(_.plaintext).map(_.toInt)
+      _ = assert(count == 3)
+
+      // Delete them all:
+      _ <- deleteThing(first)
+      _ <- deleteThing(third)
+      _ <- deleteThing(second)
+
+      // Show that they are all deleted:
+      _ <- assertNumDeletedThingsIs(3)
+      count <- evaluateQL(spaceId, "The Model._instances -> _count").map(_.plaintext).map(_.toInt)
+      _ = assert(count == 0)
+
+      // Undelete them en masse:
+      result <- evaluateQL(spaceId, """_listDeletedThings() -> _undeleteThing""")
+      // And confirm that there are no longer any deleted Things:
+      _ <- assertNumDeletedThingsIs(0)
+      count <- evaluateQL(spaceId, "The Model._instances -> _count").map(_.plaintext).map(_.toInt)
+      _ = assert(count == 3)
+
     } yield ()
   }
 }
@@ -146,6 +189,7 @@ class HistoryMidTests extends MidTestBase {
       runTest(testQIbu6oeer)
       runTest(test7w4ger8)
       runTest(test7w4gerb)
+      runTest(test7w4geta)
     }
   }
 }


### PR DESCRIPTION
This confirms that you can feed the results of `_listDeletedThings()` to `_undeleteThing`.

Along the way, found and fixed a bug in `_listDeletedThings()` -- if you didn't specify a filter, it could return duplicate deletions in the case of a Thing that had been repeatedly deleted.