### PR TITLE
QI.7w4gew0: Maintain OID mapping during imports, and use it

### DIFF
--- a/querki/scalajvm/app/models/Thing.scala
+++ b/querki/scalajvm/app/models/Thing.scala
@@ -15,162 +15,166 @@ import querki.values._
 /**
  * The root concept of the entire world. Thing is the Querki equivalent of Object,
  * the basis of the entire type system.
- * 
+ *
  * TODO: note that we thread the whole thing with OIDs, to make it easier to build the
  * whole potentially-immutable stack. Down the line, we might add a second pass that
  * re-threads these things with hard references, to make them faster to process. This
  * should do to start, though.
  */
 abstract class Thing(
-    val id:OID, 
-    val spaceId:OID, 
-    val model:OID, 
-    val kind:Kind.Kind,
-    val propMap: PropMap,
-    val modTime:DateTime) extends PropertyBundle
-{
+  val id: OID,
+  val spaceId: OID,
+  val model: OID,
+  val kind: Kind.Kind,
+  val propMap: PropMap,
+  val modTime: DateTime
+) extends PropertyBundle {
+
   /**
    * The Properties on this Thing.
-   * 
+   *
    * Yes, this is a redundant definition for the base Thing. But it is overridden in some subclasses.
    */
   lazy val props = propMap
-  
+
   /**
    * Who created this Thing, if applicable.
    */
-  def creatorOpt:Option[UserRef] = None
-  
+  def creatorOpt: Option[UserRef] = None
+
   /**
    * When this Thing was created, if known.
    */
-  def createTimeOpt:Option[DateTime] = None
-  
+  def createTimeOpt: Option[DateTime] = None
+
   /**
    * USE WITH EXTREME CAUTION: this function is for use *only* in the core classes. Its purpose is to allow
    * a Thing to fetch the value of a Property on itself (without inheritance), without using the
    * Ecology. In other words, it does an end-run around ordinary Property fetching and all the
    * type-checking built into that, and instead simply asserts "here's an OID that might exist
    * and might have a single value; if you find it, cast it to this expected type".
-   * 
+   *
    * (Why bother? It allows the core classes to declare some parameter-free lazy vals.)
-   * 
+   *
    * If you don't know what you're doing, or don't absolutely need to use this, don't.
    */
-  protected def rawLocalProp[T](pid:OID):Option[T] = {
+  protected def rawLocalProp[T](pid: OID): Option[T] = {
     for {
       qv <- props.get(pid)
       elem <- qv.firstOpt
       raw = elem.elem
-    }
-      yield raw.asInstanceOf[T]
+    } yield raw.asInstanceOf[T]
   }
-  
+
   override def toString = s"$displayName ($id)"
-  
+
   /**
    * The Name of this Thing, if there is one set.
-   * 
+   *
    * IMPORTANT: only use this if you know what you're doing. Usually, you want displayName instead.
    */
-  lazy val linkName:Option[String] = rawLocalProp[String](querki.core.MOIDs.NameOID)
-  
-  lazy val canonicalName:Option[String] = linkName.filter(_.length() > 0)
-  
-  lazy val toThingId:ThingId = {
+  lazy val linkName: Option[String] = rawLocalProp[String](querki.core.MOIDs.NameOID)
+
+  lazy val canonicalName: Option[String] = linkName.filter(_.length() > 0)
+
+  lazy val toThingId: ThingId = {
     val nameOpt = canonicalName
-    nameOpt map AsName getOrElse AsOID(id)
+    nameOpt.map(AsName).getOrElse(AsOID(id))
   }
-  
+
   /**
    * The Display Name of this Thing, rendered as a String.
-   * 
+   *
    * IMPORTANT: what gets returned from here has already been HTML-processed, and should *not*
    * be re-escaped!
    */
-  lazy val displayName:String = displayNameText.toString
-  
-  def lookupDisplayName:Option[String] = {
+  lazy val displayName: String = displayNameText.toString
+
+  def lookupDisplayName: Option[String] = {
     val dispOpt = rawLocalProp[PlainText](querki.basic.MOIDs.DisplayNameOID).map(_.text)
-    dispOpt orElse linkName
+    dispOpt.orElse(linkName)
   }
-  
+
   /**
    * The Display Name of this Thing. This is the underlying form of access, and should
    * be used to get at it as Html or HtmlWikitext. It has already been HTML-neutered, and
    * is the safest and most flexible way to use this name.
    */
-  lazy val displayNameText:DisplayText = {
+  lazy val displayNameText: DisplayText = {
     val display = for {
       localName <- lookupDisplayName
       rendered = Wikitext(localName).raw
       if (rendered.str.length() > 0)
-    }
-      yield rendered
-      
+    } yield rendered
+
     display.getOrElse(DisplayText(id.toThingId.toString))
   }
-  
+
   /**
    * The *literal* Display Name of this Thing, exactly as typed.
-   * 
+   *
    * IMPORTANT: this value has *NOT* been HTML-escaped. It must only be used in an environment that
    * will do the escaping sometime later! Do not use this casually -- always test the environment that
    * you will be using it in!
    */
-  lazy val unsafeDisplayName:String = {
+  lazy val unsafeDisplayName: String = {
     val display = for {
       localName <- lookupDisplayName
       if (localName.length() > 0)
-    }
-      yield localName
-      
+    } yield localName
+
     display.getOrElse(id.toThingId.toString)
   }
-  
-  def isThing:Boolean = true
-  def asThing:Option[Thing] = Some(this)
+
+  def oldOID: Option[OID] = {
+    rawLocalProp[OID](querki.imexport.MOIDs.OldOIDOID)
+  }
+
+  def isThing: Boolean = true
+  def asThing: Option[Thing] = Some(this)
 
   /**
    * DEPRECATED: use getModelOpt instead! It is not only more correct, it's likely to be faster!
    */
-  def getModel(implicit state:SpaceState):Thing = { 
+  def getModel(implicit state: SpaceState): Thing = {
     state.anything(model).getOrElse {
       // This is unfortunate, but when it happens, we have to recover somehow, so we fall
       // back on the most primitive possibility:
       state.anything(querki.basic.MOIDs.SimpleThingOID).get
     }
   }
-  def getModelOpt(implicit state:SpaceState):Option[Thing] = {
+
+  def getModelOpt(implicit state: SpaceState): Option[Thing] = {
     if (hasModel) Some(getModel) else None
   }
   def hasModel = (model != UnknownOID)
-  
+
   /**
    * The Property as defined on *this* specific Thing.
    */
-  def localProp(pid:OID)(implicit state:SpaceState):Option[PropAndVal[_]] = {
+  def localProp(pid: OID)(implicit state: SpaceState): Option[PropAndVal[_]] = {
     val propOpt = state.prop(pid)
     propOpt.flatMap(prop => props.get(pid).map(v => prop.pair(v)))
   }
+
   // Note that this does *not* require a SpaceState. This is very, very important, so that it can be used
   // for lazy vals:
-  def localProp[VT, CT](prop:Property[VT, _]):Option[PropAndVal[VT]] = {
-    prop.fromOpt(this.props) map prop.pair
+  def localProp[VT, CT](prop: Property[VT, _]): Option[PropAndVal[VT]] = {
+    prop.fromOpt(this.props).map(prop.pair)
   }
-  
+
   /**
    * The key method for fetching a Property Value from a Thing. This walks the tree
    * as necessary.
-   * 
+   *
    * Note that this walks up the tree recursively. It eventually ends with UrThing,
    * which does things a little differently.
    */
-  def getProp(propId:OID)(implicit state:SpaceState):PropAndVal[_] = {
+  def getProp(propId: OID)(implicit state: SpaceState): PropAndVal[_] = {
     // TODO: we're doing redundant lookups of the property. Rationalize this stack of calls.
     val propOpt = state.prop(propId)
     propOpt match {
-      case Some(prop) => 
+      case Some(prop) =>
         if (prop.notInherited)
           localOrDefault(propId)
         else
@@ -178,7 +182,8 @@ abstract class Thing(
       case None => throw new Exception("Trying to look up unknown Property " + propId)
     }
   }
-  def getProp[VT, CT](prop:Property[VT, _])(implicit state:SpaceState):PropAndVal[VT] = {
+
+  def getProp[VT, CT](prop: Property[VT, _])(implicit state: SpaceState): PropAndVal[VT] = {
     // TODO: we're doing redundant lookups of the property. Rationalize this stack of calls.
     // Note: the != here is because NotInheritedProp gets into an infinite loop otherwise:
     if (this.id != querki.core.MOIDs.NotInheritedOID && prop.notInherited)
@@ -186,20 +191,21 @@ abstract class Thing(
     else
       localProp(prop).getOrElse(getModelOpt.map(_.getProp(prop)).getOrElse(prop.defaultPair))
   }
-  
-  def localOrDefault(propId:OID)(implicit state:SpaceState):PropAndVal[_] = {
+
+  def localOrDefault(propId: OID)(implicit state: SpaceState): PropAndVal[_] = {
     val prop = state.prop(propId).getOrElse(throw new Exception("Using localOrDefault on an unknown Property!"))
     localProp(propId).getOrElse(prop.defaultPair)
   }
-  def localOrDefault[VT, CT](prop:Property[VT, _])(implicit state:SpaceState):PropAndVal[VT] = {
+
+  def localOrDefault[VT, CT](prop: Property[VT, _])(implicit state: SpaceState): PropAndVal[VT] = {
     localProp(prop).getOrElse(prop.defaultPair)
   }
-    
+
   /**
    * If you have the actual Property object you're looking for, this returns its value
    * on this object in a typesafe way.
    */
-  def getPropVal[VT, CT](prop:Property[VT, _])(implicit state:SpaceState):QValue = {
+  def getPropVal[VT, CT](prop: Property[VT, _])(implicit state: SpaceState): QValue = {
     val local = localPropVal(prop)
     if (local.isDefined)
       local.get
@@ -212,27 +218,34 @@ abstract class Thing(
   /**
    * Return the first value in the collection for this Type. This is a convenient, type-safe way to
    * get at a property value for ExactlyOne properties.
-   * 
+   *
    * IMPORTANT: this will throw an Exception if you try to call it on an Optional that is empty!
    * In general, while it is syntactically legal to call this on an Optional type, it's usually
    * inappropriate.
-   * 
+   *
    * DEPRECATED: you should use firstOpt instead!
    */
-  def first[VT](prop:Property[VT, _])(implicit state:SpaceState):VT = {
+  def first[VT](prop: Property[VT, _])(implicit state: SpaceState): VT = {
     getProp(prop).first
   }
-  
-  def localFirst[VT](prop:Property[VT, _])(implicit state:SpaceState):Option[VT] = {
-    localProp(prop) map (_.first)
+
+  def localFirst[VT](prop: Property[VT, _])(implicit state: SpaceState): Option[VT] = {
+    localProp(prop).map(_.first)
   }
-  
+
   /**
    * The good, safe way to retrieve the value of a Property, and transform it into something else.
    * Will *always* return a QValue, which will be empty iff the property isn't defined or the value
    * is empty.
    */
-  def map[VT, DT, RT](prop:Property[VT, _], destType:PType[DT] with PTypeBuilder[DT, RT])(cb:VT => RT)(implicit state:SpaceState):QValue = {
+  def map[VT, DT, RT](
+    prop: Property[VT, _],
+    destType: PType[DT] with PTypeBuilder[DT, RT]
+  )(
+    cb: VT => RT
+  )(implicit
+    state: SpaceState
+  ): QValue = {
 //    val propAndValOpt = getPropOpt(prop)
 //    propAndValOpt match {
 //      case Some(propAndVal) => propAndVal.map(destType)(cb)
@@ -243,33 +256,38 @@ abstract class Thing(
     val propAndVal = getProp(prop)
     propAndVal.map(destType)(cb)
   }
-  
+
   /**
    * Returns the first value of the specified Property *or* a given default.
    */
-  def firstOr[VT](prop:Property[VT, _], default:VT)(implicit state:SpaceState):VT = {
+  def firstOr[VT](
+    prop: Property[VT, _],
+    default: VT
+  )(implicit
+    state: SpaceState
+  ): VT = {
     val cv = getProp(prop)
     if (cv.isEmpty)
       default
     else
       cv.first
   }
-  
+
   /**
    * Returns the first value of the specified Property *or* None.
    */
-  def firstOpt[VT](prop:Property[VT, _])(implicit state:SpaceState):Option[VT] = {
+  def firstOpt[VT](prop: Property[VT, _])(implicit state: SpaceState): Option[VT] = {
     val cv = getProp(prop)
     if (cv.isEmpty)
       None
     else
       Some(cv.first)
   }
-  
+
   /**
    * Convenience method -- returns either the value of the specified property or None.
    */
-  def getPropOpt(propId:OID)(implicit state:SpaceState):Option[PropAndVal[_]] = {
+  def getPropOpt(propId: OID)(implicit state: SpaceState): Option[PropAndVal[_]] = {
     state.prop(propId).flatMap { prop =>
       if (prop.notInherited)
         localProp(prop)
@@ -277,22 +295,29 @@ abstract class Thing(
         getUntypedPropOptRec(prop, this)
     }
   }
+
   // TODO: fix the duplication of these two methods. It appears that the compiler occasionally is choosing
   // the less-powerful OID version of getPropOpt instead of the one I want, presumably through the implicit
   // conversion of Property to OID.
-  def getPropOpt[VT](prop:Property[VT, _])(implicit state:SpaceState):Option[PropAndVal[VT]] = {
+  def getPropOpt[VT](prop: Property[VT, _])(implicit state: SpaceState): Option[PropAndVal[VT]] = {
     getPropOptTyped(prop)
   }
-  def getPropOptTyped[VT](prop:Property[VT, _])(implicit state:SpaceState):Option[PropAndVal[VT]] = {
+
+  def getPropOptTyped[VT](prop: Property[VT, _])(implicit state: SpaceState): Option[PropAndVal[VT]] = {
     if (prop.notInherited)
       localProp(prop)
     else
       getPropOptRec(prop, this)
   }
-  
-  // TBD: is it possible to combine these? The Untyped version seems to be necessary to make 
+
+  // TBD: is it possible to combine these? The Untyped version seems to be necessary to make
   // getPropOpt(OID) work, but it really feels like there should be a way to work around it...
-  private def getPropOptRec[VT](prop:Property[VT, _], original:Thing)(implicit state:SpaceState):Option[PropAndVal[VT]] = {
+  private def getPropOptRec[VT](
+    prop: Property[VT, _],
+    original: Thing
+  )(implicit
+    state: SpaceState
+  ): Option[PropAndVal[VT]] = {
     localProp(prop).orElse(getModelOpt.flatMap { parent =>
       // Loop detection, so that we don't wind up with StackOverflow errors:
       if (parent.id == original.id)
@@ -301,7 +326,13 @@ abstract class Thing(
         parent.getPropOptRec(prop, original)
     })
   }
-  private def getUntypedPropOptRec(prop:Property[_, _], original:Thing)(implicit state:SpaceState):Option[PropAndVal[_]] = {
+
+  private def getUntypedPropOptRec(
+    prop: Property[_, _],
+    original: Thing
+  )(implicit
+    state: SpaceState
+  ): Option[PropAndVal[_]] = {
     localProp(prop).orElse(getModelOpt.flatMap { parent =>
       // Loop detection, so that we don't wind up with StackOverflow errors:
       if (parent.id == original.id)
@@ -310,15 +341,15 @@ abstract class Thing(
         parent.getUntypedPropOptRec(prop, original)
     })
   }
-  
+
   /**
    * The approximate size of this Thing in memory.
-   * 
+   *
    * Note that we're not worrying about making this precise -- we just want a decent ballpark for working
    * with. This should err on the low side: we don't ever want to be charging for more memory than is
    * actually being used. And we mainly care about relative sizes, more than to-the-byte exactness.
    */
-  lazy val memsize:Int = {
+  lazy val memsize: Int = {
     // The standard vals of every Thing:
     //   id: 8
     //   spaceId: 8
@@ -326,35 +357,34 @@ abstract class Thing(
     //   kind: 4
     //   timestamp: 8
     36 +
-    // Plus the sizes of the Property Map:
-    props.map { pair =>
-      val (k, v) = pair
-      // 8 for the OID of the Prop:
-      8 + v.memsize
-    }.sum
+      // Plus the sizes of the Property Map:
+      props.map { pair =>
+        val (k, v) = pair
+        // 8 for the OID of the Prop:
+        8 + v.memsize
+      }.sum
   }
-  
-  def thingOps(e:Ecology) = new ThingOps(this)(e)
+
+  def thingOps(e: Ecology) = new ThingOps(this)(e)
 }
 
 /**
  * A ThingState represents the value of a Thing as of a particular time.
  * It is immutable -- you change the Thing by going to its Space and telling it
  * to make the change.
- * 
+ *
  * Note that Models are basically just ordinary Things.
  */
 case class ThingState(
-    i:OID, 
-    s:OID, 
-    m:OID, 
-    pf: PropMap, 
-    mt:DateTime = querki.time.epoch, 
-    k:Kind.Kind = Kind.Thing, 
-    cr:Option[UserRef] = None,
-    ct:Option[DateTime] = None)
-  extends Thing(i, s, m, k, pf, mt) 
-{
+  i: OID,
+  s: OID,
+  m: OID,
+  pf: PropMap,
+  mt: DateTime = querki.time.epoch,
+  k: Kind.Kind = Kind.Thing,
+  cr: Option[UserRef] = None,
+  ct: Option[DateTime] = None
+) extends Thing(i, s, m, k, pf, mt) {
   override def creatorOpt = cr
   override def createTimeOpt = ct
 }

--- a/querki/scalajvm/app/querki/imexport/ImportSpaceActor.scala
+++ b/querki/scalajvm/app/querki/imexport/ImportSpaceActor.scala
@@ -55,6 +55,8 @@ class ImportSpaceActor(
   lazy val SpaceOps = interface[querki.spaces.SpaceOps]
   lazy val SpacePersistenceFactory = interface[querki.spaces.SpacePersistenceFactory]
 
+  // TODO: replace this silliness with proper typeclass usage, now that I have a better idea what I'm doing than
+  // I did years ago when I wrote this:
   implicit def rtc = RealRTCAble
 
   def getOIDs(nRequested: Int): RequestM[Seq[OID]] = {

--- a/querki/scalajvm/app/querki/imexport/Remapper.scala
+++ b/querki/scalajvm/app/querki/imexport/Remapper.scala
@@ -8,63 +8,82 @@ import querki.types.{ModelTypeBase, ModelTypeDefiner, SimplePropertyBundle}
 
 /**
  * This single-function trait deals with computing the OIDs for a newly imported Space.
- * 
+ *
  * IMPORTANT: this is similar to the AppRemapper, but different in a bunch of crucial ways.
  * In particular, this needs to remap *all* of the IDs, where AppRemapper only does some of
  * them. We might want to merge the two at some point, but it will need to be done with
  * extreme care in order to not break things.
- * 
+ *
  * TODO: the handling on Model Types is probably too naive here. I suspect we need to do a
  * topological sort in case of Model Types that depend on other Model Types, and rebuild
  * them in order.
  */
 trait Remapper[RM[_]] extends EcologyMember with ModelTypeDefiner {
   private lazy val Core = interface[querki.core.Core]
-  
+
+  private lazy val Imexport = interface[Imexport]
+
   private lazy val LinkType = Core.LinkType
-  
-  implicit def rtc:RTCAble[RM]
-  private implicit def rm2rtc[A](rm:RM[A]) = rtc.toRTC(rm)
-  
-  def getOIDs(size:Int):RM[Seq[OID]]
-  
+
+  implicit def rtc: RTCAble[RM]
+  private implicit def rm2rtc[A](rm: RM[A]) = rtc.toRTC(rm)
+
+  def getOIDs(size: Int): RM[Seq[OID]]
+
   /**
    * Given a proto-App, this returns that State with all of the OIDs replaced by new ones.
    * Note that this already only contains the Things that are being extracted to the App.
    */
-  def remapOIDs(stateOriginal:SpaceState):RM[(SpaceState, Map[OID, OID])] = 
-  {
+  def remapOIDs(stateOriginal: SpaceState): RM[(SpaceState, Map[OID, OID])] = {
     val allThings = stateOriginal.everythingLocal.toSeq
-      
+
     val oidsToMap = (stateOriginal.everythingLocal.toSeq :+ stateOriginal).map(_.id)
     getOIDs(oidsToMap.size).map { oids =>
       val pairs = oidsToMap.zip(oids)
-       // This is now a Map from old to new OIDs:
-      implicit val oidMap = Map(pairs:_*)
+      // This is now a Map from old to new OIDs:
+      implicit val oidMap = Map(pairs: _*)
       // Note that "and" is magic syntax sugar on SpaceState that lets me chain without creating lots
       // of intermediate names:
       val transformed =
-        remapTypes(stateOriginal)(stateOriginal) and
-        remapProps(stateOriginal) and
-        remapThings(stateOriginal) and
-        { _.copy(s = oidMap(stateOriginal.id)) } and
-        { withOwnID => withOwnID.copy(pf = remapPropMap(withOwnID, withOwnID, stateOriginal)) }
+        remapTypes(stateOriginal)(stateOriginal).and(
+          remapProps(stateOriginal)
+        ).and(
+          remapThings(stateOriginal)
+        ).and {
+          _.copy(s = oidMap(stateOriginal.id))
+        }.and {
+          withOwnID => withOwnID.copy(pf = remapPropMap(withOwnID, withOwnID, stateOriginal))
+        }
       (transformed, oidMap)
     }
   }
-  
-  private def mappedOID(oid:OID)(implicit oidMap:Map[OID, OID]):OID = {
+
+  private def mappedOID(oid: OID)(implicit oidMap: Map[OID, OID]): OID = {
     oidMap.get(oid).getOrElse(oid)
   }
-  
+
   /**
    * Remap any Links in this PropMap, if appropriate.
    */
-  private def remapPropMap(t:Thing, state:SpaceState, stateOriginal:SpaceState)(implicit oidMap:Map[OID, OID]):PropMap = {
-    remapPropMap(t.props, state, stateOriginal)
+  private def remapPropMap(
+    t: Thing,
+    state: SpaceState,
+    stateOriginal: SpaceState
+  )(implicit
+    oidMap: Map[OID, OID]
+  ): PropMap = {
+    // Note that we tack on the OldOIDProperty here, so that we keep track of the OID that this Thing had in its
+    // original image:
+    remapPropMap(t.props, state, stateOriginal) ++ Map(Imexport.OldOIDProperty(t.id))
   }
-  
-  private def remapPropMap(propsIn:PropMap, state:SpaceState, stateOriginal:SpaceState)(implicit oidMap:Map[OID, OID]):PropMap = {
+
+  private def remapPropMap(
+    propsIn: PropMap,
+    state: SpaceState,
+    stateOriginal: SpaceState
+  )(implicit
+    oidMap: Map[OID, OID]
+  ): PropMap = {
     (emptyProps /: propsIn) { case (props, (propId, propVal)) =>
       val newId = mappedOID(propId)
       val oldPropOpt = stateOriginal.prop(propId)
@@ -78,7 +97,7 @@ trait Remapper[RM[_]] extends EcologyMember with ModelTypeDefiner {
           val mtIn = prop.pType.asInstanceOf[ModelTypeDefiner#ModelType]
           val rawVals = propVal.rawList(mtIn)
           val mtOut = state.typ(mappedOID(mtIn.id)).asInstanceOf[ModelTypeDefiner#ModelType]
-          val mappedVals = rawVals.map { bundle => 
+          val mappedVals = rawVals.map { bundle =>
             mtOut(SimplePropertyBundle(remapPropMap(bundle.props, state, stateOriginal)))
           }
           prop.cType.makePropValue(mappedVals, mtOut)
@@ -88,11 +107,11 @@ trait Remapper[RM[_]] extends EcologyMember with ModelTypeDefiner {
       props + (newId -> newVal)
     }
   }
-  
-  private def remapTypes(stateOriginal:SpaceState)(stateIn:SpaceState)(implicit oidMap:Map[OID, OID]):SpaceState = {
+
+  private def remapTypes(stateOriginal: SpaceState)(stateIn: SpaceState)(implicit oidMap: Map[OID, OID]): SpaceState = {
     (stateIn /: stateIn.types.values) { (curState, typ) =>
       typ match {
-        case mt:ModelTypeDefiner#ModelType => {
+        case mt: ModelTypeDefiner#ModelType => {
           val newId = mappedOID(mt.id)
           val newType = ModelType(
             newId,
@@ -101,15 +120,15 @@ trait Remapper[RM[_]] extends EcologyMember with ModelTypeDefiner {
             mappedOID(mt.basedOn),
             remapPropMap(mt, curState, stateOriginal)
           )
-          val newTypes = (curState.types - mt.id) + (newId -> newType) 
+          val newTypes = (curState.types - mt.id) + (newId -> newType)
           curState.copy(types = newTypes)
         }
         case _ => curState
       }
     }
   }
-  
-  private def remapProps(stateOriginal:SpaceState)(stateIn:SpaceState)(implicit oidMap:Map[OID, OID]):SpaceState = {
+
+  private def remapProps(stateOriginal: SpaceState)(stateIn: SpaceState)(implicit oidMap: Map[OID, OID]): SpaceState = {
     (stateIn /: stateIn.spaceProps.values) { (curState, prop) =>
       val newId = mappedOID(prop.id)
       val newProp = prop.copy(
@@ -120,19 +139,26 @@ trait Remapper[RM[_]] extends EcologyMember with ModelTypeDefiner {
         // NOTE: not yet dealing with custom Collections!
         pf = remapPropMap(prop, curState, stateOriginal)
       )
-      val newProps = (curState.spaceProps - prop.id) + (newId -> newProp) 
+      val newProps = (curState.spaceProps - prop.id) + (newId -> newProp)
       curState.copy(spaceProps = newProps)
     }
   }
-  
-  private def remapThings(stateOriginal:SpaceState)(stateIn:SpaceState)(implicit oidMap:Map[OID, OID]):SpaceState = {
+
+  private def remapThings(
+    stateOriginal: SpaceState
+  )(
+    stateIn: SpaceState
+  )(implicit
+    oidMap: Map[OID, OID]
+  ): SpaceState = {
     (stateIn /: stateIn.things.values) { (curState, t) =>
       val newId = mappedOID(t.id)
       val newThing = t.copy(
         i = newId,
-        s = mappedOID(curState.id), 
-        m = mappedOID(t.model), 
-        pf = remapPropMap(t, curState, stateOriginal))
+        s = mappedOID(curState.id),
+        m = mappedOID(t.model),
+        pf = remapPropMap(t, curState, stateOriginal)
+      )
       val newThings = (curState.things - t.id) + (newId -> newThing)
       curState.copy(things = newThings)
     }

--- a/querki/scalajvm/app/querki/imexport/package.scala
+++ b/querki/scalajvm/app/querki/imexport/package.scala
@@ -1,7 +1,6 @@
 package querki
 
-import models.{MIMEType, Thing}
-
+import models.{MIMEType, OID, Property, Thing}
 import querki.ecology._
 import querki.values.{RequestContext, SpaceState}
 
@@ -11,13 +10,13 @@ import querki.values.{RequestContext, SpaceState}
  * we get into Synchronization.)
  */
 package object imexport {
-  
+
   final val ImportExportCategory = "Import/Export"
 
   /**
    * The flag indicating the format to import/export.
    */
-  object Format {    
+  object Format {
     val Unknown = 0
     val CSV = 1
     val XML = 2
@@ -28,27 +27,39 @@ package object imexport {
    * The results of an Export request, to be sent to the user.
    */
   trait ExportedContent {
-    def content:Array[Byte]
-    def name:String
-    def mime:MIMEType.MIMEType
+    def content: Array[Byte]
+    def name: String
+    def mime: MIMEType.MIMEType
   }
-  
+
   trait Imexport extends EcologyInterface {
+
+    /**
+     * Imported Things get this Property, saying what their original OID was in the exported Space.
+     */
+    def OldOIDProperty: Property[OID, OID]
+
     /**
      * Export the Instances of the specified Model.
-     * 
+     *
      * Will throw a PublicException if something goes wrong, so this should be wrapped in a TryTrans.
      */
-    def exportInstances(rc:RequestContext, format:Format, model:Thing)(implicit state:SpaceState):ExportedContent
-    
+    def exportInstances(
+      rc: RequestContext,
+      format: Format,
+      model: Thing
+    )(implicit
+      state: SpaceState
+    ): ExportedContent
+
     /**
      * Export an entire Space as XML.
-     * 
+     *
      * For now, we're not bothering to take a Format; I'm not sure we're ever going to do a full
      * export to anything *but* XML.
-     * 
+     *
      * TODO: in the medium term, this should produce a stream of bytes, not a String.
      */
-    def exportSpace(rc:RequestContext)(implicit state:SpaceState):String
+    def exportSpace(rc: RequestContext)(implicit state: SpaceState): String
   }
 }

--- a/querki/scalajvm/app/querki/streaming/StreamSendActor.scala
+++ b/querki/scalajvm/app/querki/streaming/StreamSendActor.scala
@@ -13,46 +13,47 @@ import UploadMessages._
  * This is a simplistic Actor, used to implement the sending side of our reliable streaming protocol. Neither
  * ask nor request are sufficient to the task, because managing possible duplication gets hairy in an
  * exactly-once protocol such as we need here.
- * 
+ *
  * Note an important assumption: since the StreamSendActor is created *locally* to the Controller, so
  * asks from the Controller to this Actor are adequately reliable.
- * 
+ *
  * The caller of this sender should be creating it locally, and using ask() to send it ByteStrings. It must
  * wait until it receives an UploadChunkAck before sending the next, and should have a timeout of at least four
  * times the timeout of the retry in here.
- * 
+ *
  * TODO: this needs unit testing!
- * 
+ *
  * @param recipient An UploadActor that will be receiving the stream.
  */
-class StreamSendActor(recipient:ActorRef) extends Actor {
-  
+class StreamSendActor(recipient: ActorRef) extends Actor {
+
   import StreamSendActor._
-  
+
   var currentIndex = 1
-  
-  var currentBlock:Option[ByteString] = None
-  
+
+  var currentBlock: Option[ByteString] = None
+
   /**
    * This is the ask mini-Actor inside uploadBodyChunks that we are currently responding to.
    */
-  var currentAsk:Option[ActorRef] = None
-  
-  var currentTimeout:Option[Cancellable] = None
-  
-  def sendBlock(attempt:Int) = { 
-    QLog.spew(s"Sending block #$currentIndex, attempt #$attempt: length ${currentBlock.get.size} ${currentBlock.get.take(4)} ... ${currentBlock.get.takeRight(4)}")
+  var currentAsk: Option[ActorRef] = None
+
+  var currentTimeout: Option[Cancellable] = None
+
+  def sendBlock(attempt: Int) = {
+//    QLog.spew(s"Sending block #$currentIndex, attempt #$attempt: length ${currentBlock.get.size} ${currentBlock.get.take(4)} ... ${currentBlock.get.takeRight(4)}")
     recipient ! UploadChunk(currentIndex, currentBlock.get.toVector)
-    currentTimeout = Some(context.system.scheduler.scheduleOnce(2 seconds, self, StreamChunkTimeout(currentIndex, attempt)))
+    currentTimeout =
+      Some(context.system.scheduler.scheduleOnce(2 seconds, self, StreamChunkTimeout(currentIndex, attempt)))
   }
-  
+
   def receive = {
-    case bytes:ByteString => {
+    case bytes: ByteString => {
       currentAsk = Some(sender)
       currentBlock = Some(bytes)
       sendBlock(0)
     }
-    
+
     case ack @ UploadChunkAck(index, totalSize) => {
       if (index == currentIndex) {
         // Okay, the current chunk is acknowledged, so send that back to the asker:
@@ -66,7 +67,7 @@ class StreamSendActor(recipient:ActorRef) extends Actor {
         // It's an obsolete Ack -- in theory, we don't care
       }
     }
-    
+
     case StreamChunkTimeout(index, attempt) => {
       if (index == currentIndex) {
         // Current attempt has timed out. How many times have we tried?
@@ -83,7 +84,7 @@ class StreamSendActor(recipient:ActorRef) extends Actor {
         // It's an obsolete timeout -- in theory, we don't care
       }
     }
-    
+
     case StreamCompleted => {
       context.stop(self)
     }
@@ -91,12 +92,15 @@ class StreamSendActor(recipient:ActorRef) extends Actor {
 }
 
 object StreamSendActor {
-  
-  def actorProps(dest:ActorRef) = Props(classOf[StreamSendActor], dest)
-  
+
+  def actorProps(dest: ActorRef) = Props(classOf[StreamSendActor], dest)
+
   /**
    * Signifies that our attempt to send this chunk has timed out.
    */
-  case class StreamChunkTimeout(index:Int, attemptNumber:Int)
+  case class StreamChunkTimeout(
+    index: Int,
+    attemptNumber: Int
+  )
   case object StreamCompleted
 }

--- a/querki/scalajvm/app/querki/streaming/UploadActor.scala
+++ b/querki/scalajvm/app/querki/streaming/UploadActor.scala
@@ -61,7 +61,7 @@ trait UploadActor { self: Actor =>
    */
   lazy val uploadedStream = {
     if (isGZip) {
-//      QLog.spew("Received GZip stream")
+      QLog.spew("Received GZip stream")
       new GZIPInputStream(baseStream)
     } else {
       baseStream
@@ -106,7 +106,7 @@ trait UploadActor { self: Actor =>
         lastIndex = index
         sender ! UploadChunkAck(index, chunkBuffer.size)
       } else {
-//        QLog.spew(s"Received duplicate of chunk #$index")
+        QLog.spew(s"UploadActor: Received duplicate of chunk #$index")
         // Although it's a duplicate, we still need to re-ack, in case our previous ack got
         // lost in transit:
         sender ! UploadChunkAck(index, chunkBuffer.size)
@@ -120,9 +120,10 @@ trait UploadActor { self: Actor =>
     case UploadComplete(rc) => {
       uploadComplete = true
 
-//      QLog.spew(s"Size of the chunkBuffer: ${chunkBuffer.size}")
-//      QLog.spew(s"Size of the chunkArray: ${chunkArray.size}")
-//      QLog.spew(s"Size of uploaded: ${uploaded.length}")
+      QLog.spew(s"Upload complete!")
+      QLog.spew(s"Size of the chunkBuffer: ${chunkBuffer.size}")
+      QLog.spew(s"Size of the chunkArray: ${chunkArray.size}")
+      QLog.spew(s"Size of uploaded String: ${uploaded.length}")
 
       processBuffer(rc)
     }


### PR DESCRIPTION
The goal here is that, when you have an Imported Space, references to the *old* OIDs will still work. We accomplish that by adding an OldOID Property to each Thing as it gets Imported, and checking that as a fallback during SpaceState lookups.

This probably doesn't cover every possible base yet, but it seems to work for at least some standard smoketests.

Also includes just a little bit of upload diagnostics, to try and start understanding why importing the Playtest Space is *still* flaky.