### PR TITLE
QI.9v5kg2b: Fix the tendency of History to OOM and kill the world

### DIFF
--- a/querki/scala/shared/src/main/scala/querki/history/HistoryFunctions.scala
+++ b/querki/scala/shared/src/main/scala/querki/history/HistoryFunctions.scala
@@ -11,38 +11,44 @@ import querki.time.Common.Timestamp
 
 trait HistoryFunctions {
   import HistoryFunctions._
-  
+
   /**
    * Fetch the complete history of this Space.
    */
-  def getHistorySummary():Future[HistorySummary]
-  
+  def getHistorySummary(): Future[HistorySummary]
+
   /**
    * Rolls this Space back to the specified version. The UI should do confirmation first!
    */
-  def rollbackTo(v:HistoryVersion):Future[SpaceInfo]
-  
+  def rollbackTo(v: HistoryVersion): Future[SpaceInfo]
+
   /**
    * Restores the specified Thing, as of the last version where it existed.
-   * 
+   *
    * We assume that the given TID is specifically from the oid field.
    */
-  def restoreDeletedThing(tid:TID):Future[ThingInfo]
+  def restoreDeletedThing(tid: TID): Future[ThingInfo]
 }
 
 object HistoryFunctions {
-  
+
   type HistoryVersion = Long
-  
+
+  val viewingHistoryParam = "_historyVersion"
+
   /**
    * Enumeration of the reasons why this Space's State was slammed.
-   * 
+   *
    * @param value The concrete enum value that gets persisted.
    */
-  sealed abstract class SetStateReason(val value:Int, val msgName:String) extends IntEnumEntry
+  sealed abstract class SetStateReason(
+    val value: Int,
+    val msgName: String
+  ) extends IntEnumEntry
+
   case object SetStateReason extends IntEnum[SetStateReason] with IntUPickleEnum[SetStateReason] {
     val values = findValues
-    
+
     case object Unknown extends SetStateReason(value = 0, msgName = "unknown")
     case object ImportedFromMySQL extends SetStateReason(value = 1, msgName = "importFromOld")
     case object ExtractedAppFromHere extends SetStateReason(value = 2, msgName = "extractedApp")
@@ -50,40 +56,89 @@ object HistoryFunctions {
     case object RolledBack extends SetStateReason(value = 4, msgName = "rolledBack")
     case object ImportedFromExport extends SetStateReason(value = 5, msgName = "importFromExport")
   }
-  
+
   /**
    * The subtypes of EvtSummary represent summary descriptions of history events.
    */
   sealed trait EvtSummary {
+
     /**
      * The index of this particular event.
      */
-    def idx:Long
+    def idx: Long
+
     /**
      * Who did this. This is an index into the whoMap.
-     * 
+     *
      * TODO: bad smell! This should be something more strongly-typed!
      */
-    def who:String
+    def who: String
+
     /**
      * When this happened.
      */
-    def time:Timestamp
+    def time: Timestamp
   }
-  case class SetStateSummary(idx:HistoryVersion, who:String, time:Timestamp, reason:SetStateReason, details:String) extends EvtSummary
-  case class ImportSummary(idx:HistoryVersion, who:String, time:Timestamp) extends EvtSummary
-  case class CreateSummary(idx:HistoryVersion, who:String, time:Timestamp, kind:Kind.Kind, id:TID, model:TID, restored:Boolean) extends EvtSummary
-  case class ModifySummary(idx:HistoryVersion, who:String, time:Timestamp, id:TID, props:Seq[TID]) extends EvtSummary
-  case class DeleteSummary(idx:HistoryVersion, who:String, time:Timestamp, id:TID) extends EvtSummary
-  case class AddAppSummary(idx:HistoryVersion, who:String, time:Timestamp, appId:TID) extends EvtSummary
-  
+
+  case class SetStateSummary(
+    idx: HistoryVersion,
+    who: String,
+    time: Timestamp,
+    reason: SetStateReason,
+    details: String
+  ) extends EvtSummary
+
+  case class ImportSummary(
+    idx: HistoryVersion,
+    who: String,
+    time: Timestamp
+  ) extends EvtSummary
+
+  case class CreateSummary(
+    idx: HistoryVersion,
+    who: String,
+    time: Timestamp,
+    kind: Kind.Kind,
+    id: TID,
+    model: TID,
+    restored: Boolean
+  ) extends EvtSummary
+
+  case class ModifySummary(
+    idx: HistoryVersion,
+    who: String,
+    time: Timestamp,
+    id: TID,
+    props: Seq[TID]
+  ) extends EvtSummary
+
+  case class DeleteSummary(
+    idx: HistoryVersion,
+    who: String,
+    time: Timestamp,
+    id: TID
+  ) extends EvtSummary
+
+  case class AddAppSummary(
+    idx: HistoryVersion,
+    who: String,
+    time: Timestamp,
+    appId: TID
+  ) extends EvtSummary
+
   type IdentityMap = Map[String, IdentityInfo]
   type ThingNames = Map[TID, String]
-  
-  case class EvtContext(whoMap:IdentityMap, thingNames:ThingNames)
-  
+
+  case class EvtContext(
+    whoMap: IdentityMap,
+    thingNames: ThingNames
+  )
+
   /**
    * The full history of this Space, in summary form.
    */
-  case class HistorySummary(events:Seq[EvtSummary], context:EvtContext)
+  case class HistorySummary(
+    events: Seq[EvtSummary],
+    context: EvtContext
+  )
 }

--- a/querki/scala/shared/src/main/scala/querki/history/HistoryFunctions.scala
+++ b/querki/scala/shared/src/main/scala/querki/history/HistoryFunctions.scala
@@ -13,9 +13,15 @@ trait HistoryFunctions {
   import HistoryFunctions._
 
   /**
-   * Fetch the complete history of this Space.
+   * Fetch some of the history of this Space.
+   *
+   * @param end the record to finish at, or None to end at the most recent version
+   * @param nRecords how many records to fetch (capped at the server end, to prevent abuse)
    */
-  def getHistorySummary(): Future[HistorySummary]
+  def getHistorySummary(
+    end: Option[HistoryVersion],
+    nRecords: Int
+  ): Future[HistorySummary]
 
   /**
    * Rolls this Space back to the specified version. The UI should do confirmation first!

--- a/querki/scalajs/src/main/scala/querki/history/HistorySummaryPage.scala
+++ b/querki/scalajs/src/main/scala/querki/history/HistorySummaryPage.scala
@@ -19,159 +19,266 @@ import querki.time.Common.Timestamp
 
 import HistoryFunctions._
 
-class HistorySummaryPage(params:ParamMap)(implicit val ecology:Ecology) 
-  extends Page("historySummary") with querki.util.ScalatagUtils
-{
+class HistorySummaryPage(params: ParamMap)(implicit val ecology: Ecology)
+  extends Page("historySummary")
+     with querki.util.ScalatagUtils {
   lazy val Client = interface[querki.client.Client]
   lazy val DataSetting = interface[querki.data.DataSetting]
   lazy val History = interface[History]
-  
+
   lazy val spaceInfo = DataAccess.space.get
-  
-  lazy val setStateMsgs = Localization.messages("history").getPackage("setStateReasons")
-  
-  case class SummaryDisplayInfo(idx:Long, who:String, time:Timestamp, title:String, details:String, colorClass:String)
-  
-  def getEvtDisplayInfo(summary:EvtSummary, whoMap:IdentityMap, thingNames:ThingNames):SummaryDisplayInfo = {
-    def lookup(id:TID):String = {
-      thingNames.get(id).map(name => s"'$name'").getOrElse("") 
+
+  val defaultNRecords = 100
+
+  implicit class RichString(s: String) {
+
+    def toLongOption: Option[Long] = {
+      try {
+        Some(s.toLong)
+      } catch {
+        case _: NumberFormatException => None
+      }
     }
-    
-    def showType(kind:Kind.Kind):String = {
+  }
+
+  lazy val nRecords: Int = params.get("nRecords").flatMap(_.toLongOption).map(_.toInt).getOrElse(defaultNRecords)
+
+  lazy val atEnd: Boolean = !params.contains("end")
+  lazy val endRecord: Option[HistoryVersion] = params.get("end").flatMap(_.toLongOption)
+
+  lazy val setStateMsgs = Localization.messages("history").getPackage("setStateReasons")
+
+  case class SummaryDisplayInfo(
+    idx: Long,
+    who: String,
+    time: Timestamp,
+    title: String,
+    details: String,
+    colorClass: String
+  )
+
+  def getEvtDisplayInfo(
+    summary: EvtSummary,
+    whoMap: IdentityMap,
+    thingNames: ThingNames
+  ): SummaryDisplayInfo = {
+    def lookup(id: TID): String = {
+      thingNames.get(id).map(name => s"'$name'").getOrElse("")
+    }
+
+    def showType(kind: Kind.Kind): String = {
       if (kind == Kind.Thing)
         ""
       else
         Kind.getName(kind).get + " "
     }
-    
+
     summary match {
       case SetStateSummary(idx, who, time, reason, details) => {
         val msg = setStateMsgs.msg(reason.msgName, ("details" -> details))
         SummaryDisplayInfo(idx, who, time, msg, "", "success")
       }
-      case ImportSummary(idx, who, time) => 
+      case ImportSummary(idx, who, time) =>
         SummaryDisplayInfo(idx, who, time, s"Imported/converted Space '${spaceInfo.displayName}'", "", "success")
-      case CreateSummary(idx, who, time, kind, id, model, restored) => 
-        SummaryDisplayInfo(idx, who, time, s"${if (restored) "Undeleted" else "Created"} ${showType(kind)}${lookup(id)}", "", "success")
-      case ModifySummary(idx, who, time, id, props) => 
-        SummaryDisplayInfo(idx, who, time, s"Edited ${lookup(id)}", s"Changed: ${props.map(lookup(_)).mkString(", ")}", "info")
+      case CreateSummary(idx, who, time, kind, id, model, restored) =>
+        SummaryDisplayInfo(
+          idx,
+          who,
+          time,
+          s"${if (restored) "Undeleted" else "Created"} ${showType(kind)}${lookup(id)}",
+          "",
+          "success"
+        )
+      case ModifySummary(idx, who, time, id, props) =>
+        SummaryDisplayInfo(
+          idx,
+          who,
+          time,
+          s"Edited ${lookup(id)}",
+          s"Changed: ${props.map(lookup(_)).mkString(", ")}",
+          "info"
+        )
       case DeleteSummary(idx, who, time, id) =>
         SummaryDisplayInfo(idx, who, time, s"Deleted ${lookup(id)}", "", "danger")
       case AddAppSummary(idx, who, time, appId) =>
         SummaryDisplayInfo(idx, who, time, s"Added app ${lookup(appId)}", "", "info")
     }
   }
-  
-  def rollbackTo(info:SummaryDisplayInfo) = {
-    val confirmDialog = new Dialog("Confirm Revert",
+
+  def rollbackTo(info: SummaryDisplayInfo) = {
+    val confirmDialog = new Dialog(
+      "Confirm Revert",
       div(
         s"""This will revert the state of this Space back to version ${info.idx}, dated ${displayTime(info.time)}. It will not
            |lose any data, but any changes made since then will be hidden. You can undo this change by reverting again, to
            |the most recent previous event. Are you sure you want to do this?""".stripMargin
       ),
-      (ButtonGadget.Warning, Seq("Revert", id:="_confirmRevert"), { dialog =>
-        Client[HistoryFunctions].rollbackTo(info.idx).call().map { reloadedSpaceInfo =>
-          dialog.done()
-          DataSetting.setSpace(Some(reloadedSpaceInfo))
-          PageManager.reload()
+      (
+        ButtonGadget.Warning,
+        Seq("Revert", id := "_confirmRevert"),
+        { dialog =>
+          Client[HistoryFunctions].rollbackTo(info.idx).call().map { reloadedSpaceInfo =>
+            dialog.done()
+            DataSetting.setSpace(Some(reloadedSpaceInfo))
+            PageManager.reload()
+          }
         }
-      }),
-      (ButtonGadget.Normal, Seq("Cancel", id:="_cancelRevert"), { dialog =>
-        dialog.done()
-      })
+      ),
+      (
+        ButtonGadget.Normal,
+        Seq("Cancel", id := "_cancelRevert"),
+        { dialog =>
+          dialog.done()
+        }
+      )
     )
-    
+
     confirmDialog.show()
   }
-  
-  def evtDisplay(summary:EvtSummary, whoMap:IdentityMap, thingNames:ThingNames) = {
+
+  def evtDisplay(
+    summary: EvtSummary,
+    whoMap: IdentityMap,
+    thingNames: ThingNames
+  ) = {
     val info = getEvtDisplayInfo(summary, whoMap, thingNames)
-    
+
     val whoName = whoMap.get(info.who).map(_.name).getOrElse("")
-    
-    new SimpleGadget(tr(
-      data("idx") := info.idx,
-      cls:=info.colorClass,
-      td(displayTime(info.time)),
-      td(whoName),
-      td(raw(info.title)),
-      td(info.details)
-    ), { e =>
-      $(e).click { evt:JQueryEventObject =>
-        val isOpen = $(e).data("isopen").map(_.asInstanceOf[Boolean]).getOrElse(false)
-        if (isOpen) {
-          val details = $(e).next()
-          details.hide("fast", { () => details.remove() })
-          $(e).data("isopen", false)
-        } else {
-          val sib = 
-            tr(
-              cls:=info.colorClass,
-              display:="none",
-              td(
-                colspan:=1,
-                new ButtonGadget(ButtonGadget.Info, "View Space") ({ () =>
-                  History.setHistoryVersion(info.idx, info.time)
-                  Pages.showSpacePage(spaceInfo)
-                })
-              ),
-              td(
-                colspan:=2,
-                new ButtonGadget(ButtonGadget.Warning, "Revert to Here") ({ () =>
-                  rollbackTo(info)
-                })
-              ),
-              summary match {
-                case DeleteSummary(idx, who, time, id) =>
-                  td(
-                    colspan:=1,
-                    new ButtonGadget(ButtonGadget.Warning, "Undelete") ({ () =>
-                      Pages.undeleteFactory.showPage("thingId" -> id.underlying, "thingName" -> thingNames.get(id).map(name => s"'$name'").getOrElse(""))
-                    })
-                  )
-                case _ => 
-                  td(
-                    colspan:=1,
-                    " "
-                  )
-              }
-            ).render
-          $(e).after(sib)
-          $(sib).show("fast")
-          $(e).data("isopen", true)
+
+    new SimpleGadget(
+      tr(
+        data("idx") := info.idx,
+        cls := info.colorClass,
+        td(displayTime(info.time)),
+        td(whoName),
+        td(raw(info.title)),
+        td(info.details)
+      ),
+      { e =>
+        $(e).click { evt: JQueryEventObject =>
+          val isOpen = $(e).data("isopen").map(_.asInstanceOf[Boolean]).getOrElse(false)
+          if (isOpen) {
+            val details = $(e).next()
+            details.hide("fast", { () => details.remove() })
+            $(e).data("isopen", false)
+          } else {
+            val sib =
+              tr(
+                cls := info.colorClass,
+                display := "none",
+                td(
+                  colspan := 1,
+                  new ButtonGadget(ButtonGadget.Info, "View Space")({ () =>
+                    History.setHistoryVersion(info.idx, info.time)
+                    Pages.showSpacePage(spaceInfo)
+                  })
+                ),
+                td(
+                  colspan := 2,
+                  new ButtonGadget(ButtonGadget.Warning, "Revert to Here")({ () =>
+                    rollbackTo(info)
+                  })
+                ),
+                summary match {
+                  case DeleteSummary(idx, who, time, id) =>
+                    td(
+                      colspan := 1,
+                      new ButtonGadget(ButtonGadget.Warning, "Undelete")({ () =>
+                        Pages.undeleteFactory.showPage(
+                          "thingId" -> id.underlying,
+                          "thingName" -> thingNames.get(id).map(name => s"'$name'").getOrElse("")
+                        )
+                      })
+                    )
+                  case _ =>
+                    td(
+                      colspan := 1,
+                      " "
+                    )
+                }
+              ).render
+            $(e).after(sib)
+            $(sib).show("fast")
+            $(e).data("isopen", true)
+          }
         }
       }
-    })
+    )
   }
-  
+
   def pageContent = for {
-    summary <- Client[HistoryFunctions].getHistorySummary().call()
+    summary <- Client[HistoryFunctions].getHistorySummary(endRecord, nRecords).call()
     HistorySummary(evts, EvtContext(whoMap, thingNames)) = summary
-    guts = 
+    startIdx = evts.head.idx
+    endIdx = evts.last.idx
+    guts =
       div(
-        h3(s"History of ${spaceInfo.displayName} ",
-          Gadget(querkiButton("Done"), { e => 
-            $(e).click({ evt:JQueryEventObject => Pages.showSpacePage(spaceInfo) })
-          }),
-          
+        h3(
+          s"History of ${spaceInfo.displayName} ",
+          Gadget(
+            querkiButton("Done"),
+            { e =>
+              $(e).click({ evt: JQueryEventObject => Pages.showSpacePage(spaceInfo) })
+            }
+          ),
           " ",
-          
-          Gadget(iconButton("refresh")(title:="Refresh this page"), { e => 
-            $(e).click({ evt:JQueryEventObject => PageManager.reload() }) 
-          })
+          Gadget(
+            iconButton("refresh")(title := "Refresh this page"),
+            { e =>
+              $(e).click({ evt: JQueryEventObject => PageManager.reload() })
+            }
+          )
         ),
-          
+        p(
+          s"""Showing records $startIdx to $endIdx """,
+          if (startIdx > 1) {
+            Gadget(
+              querkiButton("Previous records"),
+              {
+                e =>
+                  $(e).click({ evt: JQueryEventObject =>
+                    History.historySummaryFactory.showPage(
+                      "end" -> (endIdx - nRecords).toString,
+                      "nRecords" -> nRecords.toString
+                    )
+                  })
+              }
+            )
+          },
+          "  ",
+          Gadget(
+            querkiButton("Next records"),
+            {
+              e =>
+                $(e).click({ evt: JQueryEventObject =>
+                  History.historySummaryFactory.showPage(
+                    "end" -> (endIdx + nRecords).toString,
+                    "nRecords" -> nRecords.toString
+                  )
+                })
+            }
+          ),
+          "  ",
+          Gadget(
+            querkiButton("Most recent records"),
+            {
+              e =>
+                $(e).click({ evt: JQueryEventObject =>
+                  History.historySummaryFactory.showPage(
+                    "nRecords" -> nRecords.toString
+                  )
+                })
+            }
+          )
+        ),
         p(s"""The most recent events are on top. Click on an event to see more information and options.""".stripMargin),
-             
         table(
-          cls:="table table-hover",
-          
+          cls := "table table-hover",
           tbody(
             for (evt <- evts.reverse)
               yield evtDisplay(evt, whoMap, thingNames)
           )
         )
       )
-  }
-    yield PageContents(pageTitle, guts)
+  } yield PageContents(pageTitle, guts)
 }

--- a/querki/scalajs/src/main/scala/querki/pages/AdvancedPage.scala
+++ b/querki/scalajs/src/main/scala/querki/pages/AdvancedPage.scala
@@ -109,7 +109,7 @@ class AdvancedPage(params: ParamMap)(implicit val ecology: Ecology) extends Page
             //
             p("""Press this button to view the history of this Space"""),
             new ButtonGadget(ButtonGadget.Info, "View History", id := "_historyButton")({ () =>
-              History.historySummaryFactory.showPage()
+              History.historySummaryFactory.showPage("nRecords" -> "100")
             }),
             //
             p("""Press this button to export this *entire* Space as XML. (NOTE: photographs are not exported.)

--- a/querki/scalajvm/app/querki/history/FindDeleted.scala
+++ b/querki/scalajvm/app/querki/history/FindDeleted.scala
@@ -1,0 +1,118 @@
+package querki.history
+
+import querki.spaces.SpaceMessagePersistence.DHDeleteThing
+import querki.ql.QLExp
+import querki.values.{QLContext, QValue, RequestContext, SpaceState}
+import querki.globals._
+
+trait FindDeleted extends HistoryFolding with EcologyMember {
+
+  private lazy val Core = interface[querki.core.Core]
+  private lazy val QL = interface[querki.ql.QL]
+
+  private lazy val YesNoType = Core.YesNoType
+  private lazy val ExactlyOne = Core.ExactlyOne
+  private lazy val LinkType = Core.LinkType
+
+  // Copied from YesNoUtils
+  // TODO: refactor YesNoUtils so that it doesn't require being mixed in with an Ecot. The challenge is
+  // that the Ecot definition of Core isn't precisely the same as the definition here, because it is an
+  // initRequires -- it *acts* the same, but it's a different type. We we need a concept of "a way to get
+  // at Core".
+  def toBoolean(typed: QValue): Boolean = {
+    if (typed.pType == YesNoType)
+      typed.firstAs(YesNoType).getOrElse(false)
+    else
+      false
+  }
+
+  def findAllDeleted(
+    rc: RequestContext,
+    predicateOpt: Option[QLExp],
+    renderOpt: Option[QLExp]
+  ): Future[List[QValue]] = {
+    // This is a bit complex. Ultimately, we're building up a list of QValues, which are the rendered results
+    // for each deleted item. But we need to track the OID for each of those, so that we can filter out duplicates.
+    // And we need to keep track of the *previous* SpaceState before each deletion event, so that we can render
+    // the deleted item in terms of that previous state.
+    // Down at the bottom, we will throw away everything but the QValues.
+    foldOverHistory((List.empty[(QValue, OID)], emptySpace)) { (v, record) =>
+      val (soFar, prevState) = v
+      val HistoryEvent(sequenceNr, evt) = record
+      val state = evolveState(Some(prevState))(evt)
+      evt match {
+        case DHDeleteThing(req, thingId, modTime) => {
+          // Evaluate the predicate on this thing in the context of the *previous* state, when the
+          // Thing still existed:
+          val endTime = ecology.api[querki.time.TimeProvider].qlEndTime
+          val context = QLContext(ExactlyOne(LinkType(thingId)), Some(rc), endTime)(prevState, ecology)
+          val predicateResultFut: Future[Boolean] = predicateOpt match {
+            case Some(predicate) =>
+              try {
+                QL.processExp(context, predicate).map(_.value).map(toBoolean(_)).recover {
+                  case ex: Exception => { ex.printStackTrace(); false }
+                }
+              } catch {
+                case ex: Exception => Future.successful(false)
+              }
+            case _ => Future.successful(true)
+          }
+          predicateResultFut.flatMap { passes =>
+            def justTheOID(): Future[(List[(QValue, OID)], SpaceState)] = {
+              val deleted = (ExactlyOne(LinkType(thingId)), thingId)
+              val filtered = soFar.filterNot(_._2 == thingId)
+              Future.successful((deleted :: filtered, state))
+            }
+
+            if (passes) {
+              // Passes the predicate, so figure out its name, and add it to the list:
+              renderOpt.map { render =>
+                prevState.anything(thingId).map { thing =>
+                  QL.processExp(context, render).map { result =>
+                    // Remove any *previous* deletions of this Thing -- we want to wind up with only the
+                    // most recent. This is a little inefficient in Big-O terms, but I'm guessing that won't
+                    // matter a lot in reality:
+                    val deleted = (result.value, thingId)
+                    val filtered = soFar.filterNot(_._2 == thingId)
+                    (deleted :: filtered, state)
+                  }.recoverWith {
+                    case ex: Exception => {
+                      ex.printStackTrace()
+                      justTheOID()
+                    }
+                  }
+                }.getOrElse {
+                  // Oddly, we didn't find that OID in the previous state, so give up and show the raw OID:
+                  justTheOID()
+                }
+              }.getOrElse {
+                justTheOID()
+              }
+            } else {
+              // Didn't pass the predicate, so just keep going:
+              Future.successful((soFar, state))
+            }
+          }
+        }
+
+        // Anything other than deletions is ignored -- move along...
+        case _ => Future.successful((soFar, state))
+      }
+    }
+      .map { result =>
+        val (deletedPairs, state) = result
+
+        // Filter out all restored items
+        val finalDeletedPairs =
+          deletedPairs
+            .filterNot { pair =>
+              val (qv, oid) = pair
+              state.anything(oid).isDefined
+            }
+
+        // Extract just the List of QValues from all of that:
+        finalDeletedPairs.map(_._1)
+      }
+  }
+
+}

--- a/querki/scalajvm/app/querki/history/HistoryCommands.scala
+++ b/querki/scalajvm/app/querki/history/HistoryCommands.scala
@@ -7,38 +7,15 @@ import akka.util.Timeout
 import querki.console.ConsoleFunctions._
 import querki.globals._
 
-class HistoryCommands(e:Ecology) extends QuerkiEcot(e) with querki.core.MethodDefs {
+class HistoryCommands(e: Ecology) extends QuerkiEcot(e) with querki.core.MethodDefs {
   import MOIDs._
   import SpaceHistory._
-  
+
   val Console = initRequires[querki.console.Console]
   val History = initRequires[History]
-  
+
   implicit val timeout = Timeout(30 seconds)
-  
-  lazy val FindAllStompedCmd = Console.defineSpaceCommand(
-    FindAllStompedCmdOID, 
-    "Find All Stomped",
-    """This displays a list of all Things that were "stomped" by the duplicate-OID bug.""",
-    Seq(History.HistoryPerm))
-  { args =>
-    
-    val inv = args.inv 
-    implicit val state = inv.state
-    // TODO: this is icky, even though I believe it's always true. Really, all of this is proving
-    // that the whole bloody ApiImpl thing should have been done in terms of typeclasses instead
-    // of subclasses. *Sigh*.
-    val spaceApi = args.api.asInstanceOf[querki.api.SpaceApiImpl]
-    
-    for {
-      StompedThings(things) <- spaceApi.spaceRouter ? FindAllStomped()
-    }
-      yield DisplayTextResult(
-        s"""Stomped items found in Space ${state.displayName}:
-           |${things.map(item => s"  ${item.event}: ${item.display} (${item.oid})").mkString("\n")}""".stripMargin)
-  }
-  
+
   override lazy val props = Seq(
-    FindAllStompedCmd
   )
 }

--- a/querki/scalajvm/app/querki/history/HistoryEcot.scala
+++ b/querki/scalajvm/app/querki/history/HistoryEcot.scala
@@ -12,7 +12,8 @@ import querki.spaces.messages.{SpaceSubsystemRequest, ThingFound}
 import querki.util.{ActorHelpers, PublicException}
 
 object MOIDs extends EcotIds(65) {
-  val FindAllStompedCmdOID = moid(1)
+  // Dead -- we've removed this command, since we haven't used it in years:
+//  val FindAllStompedCmdOID = moid(1)
   val HistoryPermOID = moid(2)
   val UndeleteFunctionOID = moid(3)
   val ListDeletedThingsOID = moid(4)

--- a/querki/scalajvm/app/querki/history/HistoryEcot.scala
+++ b/querki/scalajvm/app/querki/history/HistoryEcot.scala
@@ -6,7 +6,7 @@ import querki.globals._
 import querki.values.RequestContext
 import HistoryFunctions._
 import models.OID
-import querki.history.SpaceHistory.{DeletedThings, ForAllDeletedThings, RestoreDeletedThing}
+import querki.history.SpaceHistory._
 import querki.ql.{QLCall, QLExp, QLThingId}
 import querki.spaces.messages.{SpaceSubsystemRequest, ThingFound}
 import querki.util.{ActorHelpers, PublicException}
@@ -154,11 +154,11 @@ class HistoryEcot(e: Ecology) extends QuerkiEcot(e) with History with querki.cor
             inv.opt(expToOid(exp), Some(PublicException("History.undeleteNotOid", exp.reconstructString)))
           case _ => inv.contextAllAs(LinkType)
         }
-        ThingFound(id, newState) <- inv.fut(
+        Restored(ids, state) <- inv.fut(
           SpaceOps.spaceRegion ?
             SpaceSubsystemRequest(inv.context.request.requesterOrAnon, inv.state.id, RestoreDeletedThing(user, oid))
         )
-      } yield ExactlyOne(LinkType(id))
+      } yield QList.makePropValue(ids.map(LinkType(_)), LinkType)
     }
   }
 

--- a/querki/scalajvm/app/querki/history/HistoryEcot.scala
+++ b/querki/scalajvm/app/querki/history/HistoryEcot.scala
@@ -39,7 +39,7 @@ class HistoryEcot(e: Ecology) extends QuerkiEcot(e) with History with querki.cor
   }
 
   def viewingHistoryVersion(rc: RequestContext): Option[HistoryVersion] = {
-    rc.rawParam("_historyVersion") match {
+    rc.rawParam(HistoryFunctions.viewingHistoryParam) match {
       case Some(vStr) =>
         Some(vStr.toLong)
       case _ => None
@@ -47,7 +47,7 @@ class HistoryEcot(e: Ecology) extends QuerkiEcot(e) with History with querki.cor
   }
 
   def isViewingHistory(rc: RequestContext): Boolean = {
-    rc.rawParam("_historyVersion").map(_.length > 0).getOrElse(false)
+    rc.rawParam(HistoryFunctions.viewingHistoryParam).map(_.length > 0).getOrElse(false)
   }
 
   ///////////////////////////////////

--- a/querki/scalajvm/app/querki/history/HistoryFolding.scala
+++ b/querki/scalajvm/app/querki/history/HistoryFolding.scala
@@ -1,0 +1,60 @@
+package querki.history
+
+import akka.persistence.query.EventEnvelope
+import querki.globals.Future
+import querki.spaces.SpaceMessagePersistence.SpaceEvent
+import querki.spaces.SpacePure
+
+/**
+ * The interesting bits from a single history record.
+ *
+ * Note that this is a subset of the underlying [[EventEnvelope]], mostly to hide the fields that I don't think we
+ * should ever care about.
+ */
+case class HistoryEvent(
+  sequenceNr: Long,
+  evt: SpaceEvent
+)
+
+/**
+ * The abstract trait that represents the ability to fold over a Space's History.
+ *
+ * This is the underlying functionality behind most History functions; it is lifted out here so that we can
+ * refactor those functions.
+ */
+trait HistoryFolding extends SpacePure {
+
+  /**
+   * Run the given evolution operation over a range of history records.
+   *
+   * @param start the sequence number of the record to start with
+   * @param end the sequence number to end at
+   * @param zero the initial state of the fold
+   * @param evolve the actual function to fold over
+   * @tparam T the type of the fold
+   * @return a Future of the result of the fold
+   */
+  def foldOverPartialHistory[T](
+    start: Long,
+    end: Long
+  )(
+    zero: T
+  )(
+    evolve: (T, HistoryEvent) => Future[T]
+  ): Future[T]
+
+  /**
+   * Run the given evolution operation over the entire history of this Space.
+   *
+   * Note that [[foldOverPartialHistory()]] is more general, but less often useful.
+   *
+   * The [[evolve]] function is async because we often need that. If the algorithm you need is synchronous, just
+   * wrap the result in Future.successful().
+   *
+   * @param zero the initial state of the fold
+   * @param evolve the actual function to fold over
+   * @tparam T the type of the fold
+   * @return a Future of the result of the fold
+   */
+  def foldOverHistory[T](zero: T)(evolve: (T, HistoryEvent) => Future[T]): Future[T]
+}

--- a/querki/scalajvm/app/querki/history/HistoryFolding.scala
+++ b/querki/scalajvm/app/querki/history/HistoryFolding.scala
@@ -1,9 +1,13 @@
 package querki.history
 
-import akka.persistence.query.EventEnvelope
-import querki.globals.Future
+import akka.actor.Actor
+import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
+import akka.persistence.query.scaladsl.{CurrentEventsByPersistenceIdQuery, ReadJournal}
+import akka.persistence.query.{EventEnvelope, PersistenceQuery}
+import akka.stream.ActorMaterializer
+import querki.globals._
 import querki.spaces.SpaceMessagePersistence.SpaceEvent
-import querki.spaces.SpacePure
+import querki.spaces.{SpacePure, TracingSpace}
 
 /**
  * The interesting bits from a single history record.
@@ -57,4 +61,76 @@ trait HistoryFolding extends SpacePure {
    * @return a Future of the result of the fold
    */
   def foldOverHistory[T](zero: T)(evolve: (T, HistoryEvent) => Future[T]): Future[T]
+}
+
+trait HistoryFoldingImpl extends Actor with HistoryFolding {
+
+  def tracing: TracingSpace
+  def persistenceId: String
+
+  // TODO: this is more than a little bit hacky. We should come up with a more principled approach to testing,
+  // likely with machinery to override Ecology members. But it'll do for now.
+  lazy val test =
+    Config.getString("akka.persistence.journal.plugin") == "inmemory-journal"
+
+  lazy val readJournal: ReadJournal with CurrentEventsByPersistenceIdQuery =
+    if (test)
+      // During tests, we are using the in-memory journal. Yes, this is the documented way to do it:
+      //   https://github.com/dnvriend/akka-persistence-inmemory
+      PersistenceQuery(context.system)
+        .readJournalFor("inmemory-read-journal")
+        .asInstanceOf[ReadJournal with CurrentEventsByPersistenceIdQuery]
+    else
+      PersistenceQuery(context.system).readJournalFor[CassandraReadJournal](CassandraReadJournal.Identifier)
+
+  /**
+   * Run the given evolution operation over a range of history records.
+   *
+   * @param start the sequence number of the record to start with
+   * @param end the sequence number to end at
+   * @param zero the initial state of the fold
+   * @param evolve the actual function to fold over
+   * @tparam T the type of the fold
+   * @return a Future of the result of the fold
+   */
+  def foldOverPartialHistory[T](
+    start: Long,
+    end: Long
+  )(
+    zero: T
+  )(
+    evolve: (T, HistoryEvent) => Future[T]
+  ): Future[T] = {
+    tracing.trace("foldOverHistory")
+    val source = readJournal.currentEventsByPersistenceId(persistenceId, start, end)
+    implicit val mat = ActorMaterializer()
+    source.runFoldAsync(zero) {
+      // Note that this quite intentionally rejects anything that isn't a SpaceEvent!
+      case (current, EventEnvelope(offset, persistenceId, sequenceNr, evt: SpaceEvent)) => {
+        evolve(current, HistoryEvent(sequenceNr, evt))
+      }
+      case (current, _) => Future.successful(current)
+    }.map { result =>
+      mat.shutdown()
+      result
+    }
+  }
+
+  /**
+   * Run the given evolution operation over the entire history of this Space.
+   *
+   * Note that [[foldOverPartialHistory()]] is more general, but less often useful.
+   *
+   * The [[evolve]] function is async because we often need that. If the algorithm you need is synchronous, just
+   * wrap the result in Future.successful().
+   *
+   * @param zero the initial state of the fold
+   * @param evolve the actual function to fold over
+   * @tparam T the type of the fold
+   * @return a Future of the result of the fold
+   */
+  def foldOverHistory[T](zero: T)(evolve: (T, HistoryEvent) => Future[T]): Future[T] = {
+    foldOverPartialHistory(1, Long.MaxValue)(zero)(evolve)
+  }
+
 }

--- a/querki/scalajvm/app/querki/history/HistoryFunctionsImpl.scala
+++ b/querki/scalajvm/app/querki/history/HistoryFunctionsImpl.scala
@@ -48,7 +48,7 @@ class HistoryFunctionsImpl(info: AutowireParams)(implicit e: Ecology)
     ThingId(tid.underlying) match {
       case AsOID(oid) => {
         for {
-          Restored(ids, newState) <- spaceRouter.request(RestoreDeletedThing(user, oid))
+          Restored(ids, newState) <- spaceRouter.request(RestoreDeletedThing(user, List(oid)))
           restored = newState.anything(oid).getOrElse(throw new Exception(s"Couldn't find Thing $tid!"))
           result <- ClientApi.thingInfo(restored, rc)(newState)
         } yield result

--- a/querki/scalajvm/app/querki/history/HistoryFunctionsImpl.scala
+++ b/querki/scalajvm/app/querki/history/HistoryFunctionsImpl.scala
@@ -3,56 +3,55 @@ package querki.history
 import models.{AsOID, ThingId}
 
 import querki.api._
-import querki.data.{SpaceInfo, ThingInfo, TID}
+import querki.data.{SpaceInfo, TID, ThingInfo}
 import querki.globals._
 import querki.spaces.messages.ThingFound
 
-class HistoryFunctionsImpl(info:AutowireParams)(implicit e:Ecology) extends SpaceApiImpl(info, e) with HistoryFunctions {
+class HistoryFunctionsImpl(info: AutowireParams)(implicit e: Ecology)
+  extends SpaceApiImpl(info, e)
+     with HistoryFunctions {
   import HistoryFunctions._
   import SpaceHistory._
-  
+
   lazy val AccessControl = interface[querki.security.AccessControl]
   lazy val ClientApi = interface[querki.api.ClientApi]
-  
-  def doRoute(req:Request):Future[String] = route[HistoryFunctions](this)(req)
-  
+
+  def doRoute(req: Request): Future[String] = route[HistoryFunctions](this)(req)
+
   // At least for the time being, we are considering History management to fall under more-general Data management.
   // We might make this more fine-grained eventually (especially for management of specific Things), but Managers
   // should always be able to do it.
   lazy val canManageHistory = AccessControl.hasPermission(AccessControl.CanManageDataPerm, state, user, state)
 
-  def getHistorySummary():Future[HistorySummary] = {
+  def getHistorySummary(): Future[HistorySummary] = {
     // Only Managers can call this:
     if (!canManageHistory)
       throw new Exception(s"Only the owner of the Space is allowed to view its history!")
-    
+
     for {
       summary <- spaceRouter.requestFor[HistorySummary](GetHistorySummary(rc))
-    }
-      yield summary
+    } yield summary
   }
-  
-  def rollbackTo(v:HistoryVersion):Future[SpaceInfo] = {
+
+  def rollbackTo(v: HistoryVersion): Future[SpaceInfo] = {
     if (!canManageHistory)
       throw new Exception(s"Only the owner of the Space is allowed to view its history!")
-    
+
     for {
       ThingFound(id, newState) <- spaceRouter.request(RollbackTo(v, user))
-    }
-      yield ClientApi.spaceInfo(newState, user)
+    } yield ClientApi.spaceInfo(newState, user)
   }
-  
-  def restoreDeletedThing(tid:TID):Future[ThingInfo] = {
+
+  def restoreDeletedThing(tid: TID): Future[ThingInfo] = {
     // TODO: this abstraction is leaking all over the place. Can we come up with a better-typed way of saying
     // that this parameter is specifically an OID, and converting it as such?
     ThingId(tid.underlying) match {
       case AsOID(oid) => {
         for {
-          ThingFound(id, newState) <- spaceRouter.request(RestoreDeletedThing(user, oid))
-          restored = newState.anything(id).getOrElse(throw new Exception(s"Couldn't find Thing $tid!"))
+          Restored(ids, newState) <- spaceRouter.request(RestoreDeletedThing(user, oid))
+          restored = newState.anything(oid).getOrElse(throw new Exception(s"Couldn't find Thing $tid!"))
           result <- ClientApi.thingInfo(restored, rc)(newState)
-        }
-          yield result
+        } yield result
       }
       case _ => throw new Exception(s"restoreDeletedThing currently only works with OIDs!")
     }

--- a/querki/scalajvm/app/querki/history/HistorySummaryBuilder.scala
+++ b/querki/scalajvm/app/querki/history/HistorySummaryBuilder.scala
@@ -1,0 +1,176 @@
+package querki.history
+
+import org.querki.requester.{RequestM, Requester}
+import querki.data.TID
+
+import scala.collection.immutable.Queue
+import querki.values.{RequestContext, SpaceState}
+import querki.globals._
+import querki.history.HistoryFunctions.{
+  AddAppSummary,
+  CreateSummary,
+  DeleteSummary,
+  EvtContext,
+  EvtSummary,
+  HistorySummary,
+  HistoryVersion,
+  ImportSummary,
+  ModifySummary,
+  SetStateReason,
+  SetStateSummary,
+  ThingNames
+}
+import querki.identity.IdentityPersistence.UserRef
+import querki.spaces.SpaceMessagePersistence._
+import querki.time._
+
+/**
+ * This encapsulates the ability to build a summary of a Space's History, for sending to the front end.
+ */
+trait HistorySummaryBuilder extends EcologyMember with Requester with HistoryFolding {
+
+  private lazy val ClientApi = interface[querki.api.ClientApi]
+  private lazy val IdentityAccess = interface[querki.identity.IdentityAccess]
+
+  case class HistoryScanState(
+    evts: Queue[EvtSummary],
+    identityIds: Set[OID],
+    thingsIds: Set[OID],
+    state: SpaceState
+  )
+
+  implicit def OID2TID(oid: OID): TID = ClientApi.OID2TID(oid)
+
+  def toSummary(
+    evt: SpaceEvent,
+    sequenceNr: Long,
+    identities: Set[OID],
+    allThingIds: Set[OID]
+  )(implicit
+    state: SpaceState
+  ): (EvtSummary, Set[OID], Set[OID]) = {
+    def fill(
+      userRef: UserRef,
+      thingIds: Seq[OID],
+      f: String => EvtSummary
+    ): (EvtSummary, Set[OID], Set[OID]) = {
+      val summary = f(userRef.identityIdOpt.map(_.toThingId.toString).getOrElse(""))
+
+      val newIdentities = userRef.identityIdOpt match {
+        case Some(identityId) => identities + identityId
+        case None             => identities
+      }
+
+      val namePairs = for {
+        thingId <- thingIds
+        thing <- state.anything(thingId)
+      } yield (thingId, thing.displayName)
+
+      val newThingIds =
+        (allThingIds /: namePairs) { (tn, pair) =>
+          val (id, name) = pair
+          tn + id
+        }
+
+      (summary, newIdentities, newThingIds)
+    }
+
+    evt match {
+      case DHSetState(dh, modTime, reason, details) =>
+        (
+          SetStateSummary(
+            sequenceNr,
+            "",
+            modTime.toTimestamp,
+            SetStateReason.withValue(reason.getOrElse(0)),
+            details.getOrElse("")
+          ),
+          identities,
+          allThingIds
+        )
+
+      case DHInitState(userRef, display) => fill(userRef, Seq.empty, ImportSummary(sequenceNr, _, 0))
+
+      case DHCreateThing(req, thingId, kind, modelId, dhProps, modTime, restored) =>
+        fill(
+          req,
+          dhProps.keys.toSeq :+ thingId,
+          CreateSummary(sequenceNr, _, modTime.toTimestamp, kind, thingId, modelId, restored.getOrElse(false))
+        )
+
+      case DHModifyThing(req, thingId, modelIdOpt, propChanges, replaceAllProps, modTime) =>
+        fill(
+          req,
+          propChanges.keys.toSeq :+ thingId,
+          ModifySummary(sequenceNr, _, modTime.toTimestamp, thingId, propChanges.keys.toSeq.map(OID2TID))
+        )
+
+      case DHDeleteThing(req, thingId, modTime) =>
+        fill(req, Seq(thingId), DeleteSummary(sequenceNr, _, modTime.toTimestamp, thingId))
+
+      case DHAddApp(req, modTime, app, appParents, shadowMapping, _) =>
+        fill(req, Seq(app.id), AddAppSummary(sequenceNr, _, modTime.toTimestamp, app.id))
+    }
+  }
+
+  def scanHistory(
+    endOpt: Option[HistoryVersion],
+    maxRecords: Int
+  ): Future[HistoryScanState] = {
+    val end = endOpt.getOrElse(Long.MaxValue)
+    foldOverPartialHistory(1, end)(HistoryScanState(Queue.empty, Set.empty, Set.empty, emptySpace)) {
+      (scanState, historyEvt) =>
+        val HistoryScanState(evtsIn, identities, thingIds, prevState) = scanState
+        val evts =
+          if (evtsIn.size == maxRecords) {
+            evtsIn.dequeue._2
+          } else {
+            evtsIn
+          }
+        val evt = historyEvt.evt
+        val state = evolveState(Some(prevState))(evt)
+        val (summary, newIdentities, newThingIds) =
+          toSummary(evt, historyEvt.sequenceNr, identities, thingIds)(state)
+        Future.successful(HistoryScanState(evts.enqueue(summary), newIdentities, newThingIds, state))
+    }
+  }
+
+  /**
+   * Run through the OIDs needed for the History, and get their Names. We have to do this in a
+   * second pass because, in order to cope with Computed Names, this needs to be done with Future.
+   */
+  def mapNames(
+    ids: Set[OID]
+  )(implicit
+    rc: RequestContext,
+    state: SpaceState
+  ): Future[ThingNames] = {
+    (Future.successful(Map.empty[TID, String]) /: ids) { (fut, id) =>
+      fut.flatMap { m =>
+        state.anything(id) match {
+          case Some(t) => t.nameOrComputed.map(name => m + (OID2TID(id) -> name))
+          case _       => Future.successful(m)
+        }
+      }
+    }
+  }
+
+  def getHistorySummary(
+    end: Option[HistoryVersion],
+    maxRecords: Int,
+    rc: RequestContext
+  ): RequestM[HistorySummary] = {
+    val resultFut = for {
+      HistoryScanState(evts, identityIds, thingIds, latestState) <- scanHistory(end, maxRecords)
+      thingNames <- mapNames(thingIds)(rc, latestState)
+      identities <- IdentityAccess.getIdentities(identityIds.toSeq)
+      identityMap = identities.map {
+        case (id, publicIdentity) =>
+          (id.toThingId.toString -> ClientApi.identityInfo(publicIdentity))
+      }
+    } yield HistorySummary(evts, EvtContext(identityMap, thingNames))
+
+    loopback(resultFut)
+  }
+
+}

--- a/querki/scalajvm/app/querki/history/RestoreDeleted.scala
+++ b/querki/scalajvm/app/querki/history/RestoreDeleted.scala
@@ -1,0 +1,88 @@
+package querki.history
+
+import akka.actor.ActorRef
+import querki.spaces.messages.{CreateThing, ThingFound}
+import querki.values.SpaceState
+import querki.globals._
+import querki.spaces.SpaceMessagePersistence.DHDeleteThing
+import org.querki.requester.{RequestM, Requester}
+import querki.identity.User
+import models.Thing
+
+trait RestoreDeleted extends HistoryFolding with Requester {
+
+  def spaceRouter: ActorRef
+
+  case class RestoreScanState(
+    prevState: SpaceState,
+    lastKnownVersions: Map[OID, Thing]
+  )
+
+  /**
+   * Scan through the history, and find the last version of each specified Thing before it was deleted.
+   */
+  def findLastKnownVersions(thingIds: Set[OID]): Future[Map[OID, Thing]] = {
+    foldOverHistory(RestoreScanState(emptySpace, Map.empty)) { (scanState, historyEvt) =>
+      val lastKnownVersions =
+        historyEvt.evt match {
+          case DHDeleteThing(req, id, modTime) if (thingIds.contains(id)) => {
+            // This is one of the Things we want to restore, so grab its previous state:
+            scanState.prevState.anything(id) match {
+              case Some(thing) => scanState.lastKnownVersions + (id -> thing)
+              case None        => scanState.lastKnownVersions
+            }
+          }
+          case _ => scanState.lastKnownVersions
+        }
+      val state = evolveState(Some(scanState.prevState))(historyEvt.evt)
+      Future.successful(RestoreScanState(state, lastKnownVersions))
+    }.map(_.lastKnownVersions)
+  }
+
+  def restoreOneFromLastKnown(
+    user: User,
+    thing: Thing
+  ): RequestM[ThingFound] = {
+    val createMsg =
+      CreateThing(
+        user,
+        id,
+        thing.kind,
+        thing.model,
+        thing.props,
+        Some(thing.id),
+        creatorOpt = thing.creatorOpt,
+        createTimeOpt = thing.createTimeOpt
+      )
+
+    spaceRouter.request(createMsg).map {
+      case found: ThingFound => found
+      case other => {
+        val msg = s"Got $other when trying to recreate thing $thing"
+        QLog.error(msg)
+        throw new Exception(msg)
+      }
+    }
+  }
+
+  def restoreFromLastKnowns(
+    user: User,
+    lastKnownVersions: Map[OID, Thing]
+  ): RequestM[SpaceState] = {
+    lastKnownVersions.foldLeft(RequestM.successful(emptySpace)) { (prevReq, pair) =>
+      val (oid, thing) = pair
+      prevReq.flatMap(_ => restoreOneFromLastKnown(user, thing).map(_.state))
+    }
+  }
+
+  def restoreDeletedThings(
+    user: User,
+    thingIds: Set[OID]
+  ): RequestM[SpaceState] = {
+    for {
+      lastKnownVersions <- loopback(findLastKnownVersions(thingIds))
+      resultingState <- restoreFromLastKnowns(user, lastKnownVersions)
+    } yield resultingState
+  }
+
+}

--- a/querki/scalajvm/app/querki/history/SpaceHistory.scala
+++ b/querki/scalajvm/app/querki/history/SpaceHistory.scala
@@ -60,16 +60,11 @@ private[history] class SpaceHistory(
      with TimeoutChild
      with HistoryFolding
      with RestoreDeleted
-     with HistorySummaryBuilder {
+     with HistorySummaryBuilder
+     with FindDeleted {
   lazy val Basic = interface[querki.basic.Basic]
-  lazy val Core = interface[querki.core.Core]
   lazy val Person = interface[querki.identity.Person]
-  lazy val QL = interface[querki.ql.QL]
   lazy val SystemState = interface[querki.system.System].State
-
-  lazy val ExactlyOne = Core.ExactlyOne
-  lazy val LinkType = Core.LinkType
-  lazy val YesNoType = Core.YesNoType
 
   def timeoutConfig: String = "querki.history.timeout"
 
@@ -206,107 +201,6 @@ private[history] class SpaceHistory(
       // This is rather weird -- we didn't get any events:
       HistoryRecord(0, DHInitState(UserRef(User.Anonymous.id, None), ""), emptySpace)
     }))
-  }
-
-  // Copied from YesNoUtils
-  // TODO: refactor YesNoUtils so that it doesn't require being mixed in with an Ecot. The challenge is
-  // that the Ecot definition of Core isn't precisely the same as the definition here, because it is an
-  // initRequires -- it *acts* the same, but it's a different type. We we need a concept of "a way to get
-  // at Core".
-  def toBoolean(typed: QValue): Boolean = {
-    if (typed.pType == YesNoType)
-      typed.firstAs(YesNoType).getOrElse(false)
-    else
-      false
-  }
-
-  def findAllDeleted(
-    rc: RequestContext,
-    predicateOpt: Option[QLExp],
-    renderOpt: Option[QLExp]
-  ): Future[List[QValue]] = {
-    // This is a bit complex. Ultimately, we're building up a list of QValues, which are the rendered results
-    // for each deleted item. But we need to track the OID for each of those, so that we can filter out duplicates.
-    // And we need to keep track of the *previous* SpaceState before each deletion event, so that we can render
-    // the deleted item in terms of that previous state.
-    // Down at the bottom, we will throw away everything but the QValues.
-    foldOverHistory((List.empty[(QValue, OID)], emptySpace)) { (v, record) =>
-      val (soFar, prevState) = v
-      val HistoryEvent(sequenceNr, evt) = record
-      val state = evolveState(Some(prevState))(evt)
-      evt match {
-        case DHDeleteThing(req, thingId, modTime) => {
-          // Evaluate the predicate on this thing in the context of the *previous* state, when the
-          // Thing still existed:
-          val endTime = ecology.api[querki.time.TimeProvider].qlEndTime
-          val context = QLContext(ExactlyOne(LinkType(thingId)), Some(rc), endTime)(prevState, ecology)
-          val predicateResultFut: Future[Boolean] = predicateOpt match {
-            case Some(predicate) =>
-              try {
-                QL.processExp(context, predicate).map(_.value).map(toBoolean(_)).recover {
-                  case ex: Exception => { ex.printStackTrace(); false }
-                }
-              } catch {
-                case ex: Exception => Future.successful(false)
-              }
-            case _ => Future.successful(true)
-          }
-          predicateResultFut.flatMap { passes =>
-            def justTheOID(): Future[(List[(QValue, OID)], SpaceState)] = {
-              val deleted = (ExactlyOne(LinkType(thingId)), thingId)
-              val filtered = soFar.filterNot(_._2 == thingId)
-              Future.successful((deleted :: filtered, state))
-            }
-
-            if (passes) {
-              // Passes the predicate, so figure out its name, and add it to the list:
-              renderOpt.map { render =>
-                prevState.anything(thingId).map { thing =>
-                  QL.processExp(context, render).map { result =>
-                    // Remove any *previous* deletions of this Thing -- we want to wind up with only the
-                    // most recent. This is a little inefficient in Big-O terms, but I'm guessing that won't
-                    // matter a lot in reality:
-                    val deleted = (result.value, thingId)
-                    val filtered = soFar.filterNot(_._2 == thingId)
-                    (deleted :: filtered, state)
-                  }.recoverWith {
-                    case ex: Exception => {
-                      ex.printStackTrace()
-                      justTheOID()
-                    }
-                  }
-                }.getOrElse {
-                  // Oddly, we didn't find that OID in the previous state, so give up and show the raw OID:
-                  justTheOID()
-                }
-              }.getOrElse {
-                justTheOID()
-              }
-            } else {
-              // Didn't pass the predicate, so just keep going:
-              Future.successful((soFar, state))
-            }
-          }
-        }
-
-        // Anything other than deletions is ignored -- move along...
-        case _ => Future.successful((soFar, state))
-      }
-    }
-      .map { result =>
-        val (deletedPairs, state) = result
-
-        // Filter out all restored items
-        val finalDeletedPairs =
-          deletedPairs
-            .filterNot { pair =>
-              val (qv, oid) = pair
-              state.anything(oid).isDefined
-            }
-
-        // Extract just the List of QValues from all of that:
-        finalDeletedPairs.map(_._1)
-      }
   }
 
   def getCurrentState(): RequestM[SpaceState] = {

--- a/querki/scalajvm/app/querki/history/SpaceHistory.scala
+++ b/querki/scalajvm/app/querki/history/SpaceHistory.scala
@@ -89,10 +89,9 @@ private[history] class SpaceHistory(
   }
 
   def doReceive = {
-    case GetHistorySummary(rc) => {
+    case GetHistorySummary(rc, end, nRecords) => {
       tracing.trace(s"GetHistorySummary")
-      // TODO: get the end and maxRecords from the front end:
-      getHistorySummary(None, 1000, rc).map { summary =>
+      getHistorySummary(end, nRecords, rc).map { summary =>
         sender ! summary
       }
     }
@@ -163,7 +162,11 @@ object SpaceHistory {
   /**
    * Fetches the HistorySummary (as described in the public API).
    */
-  case class GetHistorySummary(rc: RequestContext) extends HistoryMessage
+  case class GetHistorySummary(
+    rc: RequestContext,
+    end: Option[HistoryVersion],
+    nRecords: Int
+  ) extends HistoryMessage
 
   /**
    * Fetch a specific version of the history of this Space. Returns a CurrentState().

--- a/querki/scalajvm/app/querki/history/SpaceHistory.scala
+++ b/querki/scalajvm/app/querki/history/SpaceHistory.scala
@@ -469,6 +469,78 @@ private[history] class SpaceHistory(
     loopback(resultFut)
   }
 
+  case class RestoreScanState(
+    prevState: SpaceState,
+    lastKnownVersions: Map[OID, Thing]
+  )
+
+  /**
+   * Scan through the history, and find the last version of each specified Thing before it was deleted.
+   */
+  def findLastKnownVersions(thingIds: Set[OID]): Future[Map[OID, Thing]] = {
+    foldOverHistory(RestoreScanState(emptySpace, Map.empty)) { (scanState, historyEvt) =>
+      val lastKnownVersions =
+        historyEvt.evt match {
+          case DHDeleteThing(req, id, modTime) if (thingIds.contains(id)) => {
+            // This is one of the Things we want to restore, so grab its previous state:
+            scanState.prevState.anything(id) match {
+              case Some(thing) => scanState.lastKnownVersions + (id -> thing)
+              case None        => scanState.lastKnownVersions
+            }
+          }
+          case _ => scanState.lastKnownVersions
+        }
+      val state = evolveState(Some(scanState.prevState))(historyEvt.evt)
+      Future.successful(RestoreScanState(state, lastKnownVersions))
+    }.map(_.lastKnownVersions)
+  }
+
+  def restoreOneFromLastKnown(
+    user: User,
+    thing: Thing
+  ): RequestM[ThingFound] = {
+    val createMsg =
+      CreateThing(
+        user,
+        id,
+        thing.kind,
+        thing.model,
+        thing.props,
+        Some(thing.id),
+        creatorOpt = thing.creatorOpt,
+        createTimeOpt = thing.createTimeOpt
+      )
+
+    spaceRouter.request(createMsg).map {
+      case found: ThingFound => found
+      case other => {
+        val msg = s"Got $other when trying to recreate thing $thing"
+        QLog.error(msg)
+        throw new Exception(msg)
+      }
+    }
+  }
+
+  def restoreFromLastKnowns(
+    user: User,
+    lastKnownVersions: Map[OID, Thing]
+  ): RequestM[SpaceState] = {
+    lastKnownVersions.foldLeft(RequestM.successful(emptySpace)) { (prevReq, pair) =>
+      val (oid, thing) = pair
+      prevReq.flatMap(_ => restoreOneFromLastKnown(user, thing).map(_.state))
+    }
+  }
+
+  def restoreDeletedThings(
+    user: User,
+    thingIds: Set[OID]
+  ): RequestM[SpaceState] = {
+    for {
+      lastKnownVersions <- loopback(findLastKnownVersions(thingIds))
+      resultingState <- restoreFromLastKnowns(user, lastKnownVersions)
+    } yield resultingState
+  }
+
   def doReceive = {
     case GetHistorySummary(rc) => {
       tracing.trace(s"GetHistorySummary")
@@ -500,53 +572,8 @@ private[history] class SpaceHistory(
 
     case RestoreDeletedThing(user, thingId) => {
       tracing.trace(s"RestoreDeletedThing($thingId)")
-      readCurrentHistory().map { _ =>
-        // Sanity-check: don't try to recreate the Thing if it currently exists!
-        history.last.state.anything(thingId) match {
-          case Some(thing) => {
-            // We don't need to do anything, because it's not currently deleted
-            sender ! ThingFound(thingId, history.last.state)
-          }
-
-          case None => {
-            // The normal case: it's not there
-            // Seek backwards through the History until we find this Thing.
-            // There might be an abstraction fighting to break out here: keep an eye open for
-            // other functions that want this "look backwards until" behavior.
-            @annotation.tailrec
-            def findThingRec(index: Int): Option[Thing] = {
-              if (index < 0)
-                None
-              else
-                history(index).state.anything(thingId) match {
-                  case Some(thing) => Some(thing)
-                  case None        => findThingRec(index - 1)
-                }
-            }
-
-            findThingRec(history.size - 1) match {
-              case Some(thing) => {
-                val createMsg =
-                  CreateThing(
-                    user,
-                    id,
-                    thing.kind,
-                    thing.model,
-                    thing.props,
-                    Some(thingId),
-                    creatorOpt = thing.creatorOpt,
-                    createTimeOpt = thing.createTimeOpt
-                  )
-                spaceRouter.request(createMsg).foreach {
-                  case resp: ThingFound => sender ! resp
-                  case other =>
-                    throw new Exception(s"RestoreDeletedThing, in Space $id, for Thing $thingId, got response $other!")
-                }
-              }
-              case None => throw new Exception(s"RestoreDeletedThing couldn't find Thing $thingId!")
-            }
-          }
-        }
+      restoreDeletedThings(user, Set(thingId)).map { resultingState =>
+        sender ! Restored(Seq(thingId), resultingState)
       }
     }
 
@@ -614,6 +641,14 @@ object SpaceHistory {
     user: User,
     thingId: OID
   ) extends HistoryMessage
+
+  /**
+   * Response from [[RestoreDeletedThing]].
+   */
+  case class Restored(
+    thingIds: Seq[OID],
+    state: SpaceState
+  )
 
   /**
    * Return the current State.

--- a/querki/scalajvm/app/querki/history/SpaceHistory.scala
+++ b/querki/scalajvm/app/querki/history/SpaceHistory.scala
@@ -117,10 +117,10 @@ private[history] class SpaceHistory(
       }
     }
 
-    case RestoreDeletedThing(user, thingId) => {
-      tracing.trace(s"RestoreDeletedThing($thingId)")
-      restoreDeletedThings(user, Set(thingId)).map { resultingState =>
-        sender ! Restored(Seq(thingId), resultingState)
+    case RestoreDeletedThing(user, thingIds) => {
+      tracing.trace(s"RestoreDeletedThing($thingIds)")
+      restoreDeletedThings(user, thingIds.toSet).map { resultingState =>
+        sender ! Restored(thingIds, resultingState)
       }
     }
 
@@ -186,7 +186,7 @@ object SpaceHistory {
    */
   case class RestoreDeletedThing(
     user: User,
-    thingId: OID
+    thingIds: Seq[OID]
   ) extends HistoryMessage
 
   /**

--- a/querki/scalajvm/app/querki/ql/Invocation.scala
+++ b/querki/scalajvm/app/querki/ql/Invocation.scala
@@ -263,6 +263,15 @@ private[ql] case class InvocationImpl(
     }
   }
 
+  def contextAllAsList[VT](pt: PType[VT]): InvocationValue[List[VT]] = {
+    if (!context.value.matchesType(pt))
+      error("Func.notThing", displayName)
+    else {
+      val vs = Some(context.value.rawList(pt)) //context.value.flatMap(pt)(Some(_))
+      InvocationValueImpl(vs)
+    }
+  }
+
   def contextFirstThing: InvocationValue[Thing] = {
     contextFirstAs(Core.LinkType).flatMap { oid =>
       state.anything(oid) match {

--- a/querki/scalajvm/app/querki/ql/package.scala
+++ b/querki/scalajvm/app/querki/ql/package.scala
@@ -191,6 +191,14 @@ package object ql {
     def contextAllAs[VT](pt: PType[VT]): InvocationValue[VT]
 
     /**
+     * Fetches all the elements in the received context as a List.
+     *
+     * This is *not* usually the right thing to do -- usually you should favor [[contextAllAs()]] -- but is
+     * occasionally correct when you really do want to deal with the entire received collection at once.
+     */
+    def contextAllAsList[VT](pt: PType[VT]): InvocationValue[List[VT]]
+
+    /**
      * If the received context is of the specified type, returns the first element of that context
      * monadically.
      *

--- a/querki/scalajvm/app/querki/system/SystemCreator.scala
+++ b/querki/scalajvm/app/querki/system/SystemCreator.scala
@@ -1,130 +1,140 @@
 package querki.system
 
 import akka.actor.{ActorRef, ActorSystem}
-
 import querki.ecology._
 
 /**
  * The master owner of the Official Ecology.
- * 
+ *
  * This knows how to construct all the main pieces of the system. Test code *may* use it,
  * but is not required to do so -- it is entirely normal to build a test harness that is
  * composed mainly of stubs.
  */
 object SystemCreator {
+
   /**
    * This creates the Ecots that really should not be used in unit testing, because they work
    * with the database.
    */
-  def createDBEcots(ecology:Ecology) = {
-    new querki.identity.UserPersistence(ecology)                   // 30    
-    new querki.spaces.DBSpacePersistenceFactory(ecology)           // 38
+  def createDBEcots(ecology: Ecology) = {
+    new querki.identity.UserPersistence(ecology) // 30
+    new querki.spaces.DBSpacePersistenceFactory(ecology) // 38
 //  new querki.apps.AppsPersistenceEcot(ecology)                   // 60
   }
-  
+
   /**
    * This creates the other Ecots that need to be stubbed in unit testing.
    */
-  def createStubbableEcots(ecology:Ecology, actorSystem:Option[ActorSystem], asyncInitTarget:ActorRef) = {
-    new querki.system.SystemEcot(ecology, actorSystem, asyncInitTarget)             // 18
-    new controllers.PublicUrlDefinitions(ecology)                  // 53
-    new querki.time.TimeProviderEcot(ecology)                      // 75
+  def createStubbableEcots(
+    ecology: Ecology,
+    actorSystem: Option[ActorSystem],
+    asyncInitTarget: ActorRef
+  ) = {
+    new querki.system.SystemEcot(ecology, actorSystem, asyncInitTarget) // 18
+    new controllers.PublicUrlDefinitions(ecology) // 53
+    new querki.time.TimeProviderEcot(ecology) // 75
+    new querki.test.TestingEcot(ecology) // 78
   }
-  
+
   /**
    * This creates the Ecots that can potentially be used in testing.
-   * 
+   *
    * As of this writing, I haven't gone through this list carefully. Some of these
    * will need to be moved to createDBEcots eventually.
    */
-  def createTestableEcots(ecology:Ecology) = {
+  def createTestableEcots(ecology: Ecology) = {
     // IMPORTANT: The numbers attached to these Ecots must NEVER BE CHANGED!!!!! They
     // get built into the moid's, and thence into the database! If an Ecot is removed,
     // comment it out, but leave its number and all others alone.
-    new querki.css.StylesheetModule(ecology)                       // 1
-    new querki.email.EmailModule(ecology)                     // 2
-    new querki.identity.PersonModule(ecology)                      // 3
-    new querki.security.AccessControlModule(ecology)               // 4
-    new querki.time.TimeModule(ecology)                            // 5
-    new querki.collections.CollectionsModule(ecology)              // 6
+    new querki.css.StylesheetModule(ecology) // 1
+    new querki.email.EmailModule(ecology) // 2
+    new querki.identity.PersonModule(ecology) // 3
+    new querki.security.AccessControlModule(ecology) // 4
+    new querki.time.TimeModule(ecology) // 5
+    new querki.collections.CollectionsModule(ecology) // 6
 //  new render.RenderingModule(ecology)                            // 7
-    new querki.system.TOSModule(ecology)                           // 8
-    new querki.logic.LogicModule(ecology)                          // 9
-    new querki.types.impl.TypesModule(ecology)                     // 10
-    new querki.html.UIModule(ecology)                              // 11
-    new querki.types.DeriveNameModule(ecology)                     // 12
-    new querki.editing.EditorModule(ecology)                       // 13
-    new querki.identity.skilllevel.impl.SkillLevelModule(ecology)  // 14
-    new querki.conventions.ConventionsModule(ecology)              // 15
-    new querki.core.CoreModule(ecology)                            // 16
-    new querki.basic.BasicModule(ecology)                          // 17
-                                                                   // 18
-    new querki.search.SearchEcot(ecology)                          // 19
-    new querki.core.PropListManagerEcot(ecology)                   // 20
-    new querki.datamodel.DataModelAccessEcot(ecology)              // 21
-    new querki.tags.TagsEcot(ecology)                              // 22
-    new querki.text.TextEcot(ecology)                              // 23
-    new querki.ql.QLEcot(ecology)                                  // 24
-    new querki.spaces.PropTypeMigratorEcot(ecology)                // 25
-    new querki.html.HtmlRendererEcot(ecology)                      // 26
-    new querki.links.LinksEcot(ecology)                            // 27
-    new querki.spaces.SpacePersistenceEcot(ecology)                // 28
-    new querki.evolutions.EvolutionsEcot(ecology)                  // 29
-                                                                   // 30
-    new controllers.PageEventManagerEcot(ecology)                  // 31
-    new querki.spaces.SpaceChangeManagerEcot(ecology)              // 32    
-    new querki.imexport.ImexportEcot(ecology)                      // 33
-    new querki.datamodel.introspection.IntrospectionEcot(ecology)  // 34
-    new querki.conversations.ConversationEcot(ecology)             // 35
-    new querki.collections.GroupingEcot(ecology)                   // 36
-    new querki.spaces.SpaceEcot(ecology)                           // 37
-                                                                   // 38
-    new querki.identity.IdentityEcot(ecology)                      // 39
-    new controllers.NavSectionEcot(ecology)                        // 40
-    new querki.types.PropPathEcot(ecology)                         // 41
-    new querki.security.EncryptionEcot(ecology)                    // 42
-    new querki.admin.AdminEcot(ecology)                            // 43
-    new querki.uservalues.UserValueEcot(ecology)                   // 44
-    new querki.uservalues.RatingEcot(ecology)                      // 45
-    new querki.links.ExternalLinkEcot(ecology)                     // 46
-    new querki.session.SessionEcot(ecology)                        // 47
-    new querki.notifications.NotificationEcot(ecology)             // 48
-    new querki.notifications.NotificationPersistenceEcot(ecology)  // 49
-    new querki.conversations.CommentNotifierEcot(ecology)          // 50
-    new querki.security.RolesEcot(ecology)                         // 51
-    new querki.photos.PhotoEcot(ecology)                           // 52
-                                     // 53
-    new querki.api.ClientApiEcot(ecology)                          // 54
-    new querki.tools.ProfilerEcot(ecology)                         // 55
-    new querki.api.ApiManagement(ecology)                          // 56
-    new querki.time.DurationEcot(ecology)                          // 57
-    new querki.cluster.ClusterEcot(ecology)                        // 58
-    new querki.apps.AppsEcot(ecology)                              // 59
-                                     // 60
-    new querki.ql.SignatureEcot(ecology)                           // 61
-    new querki.core.FunctionEcot(ecology)                          // 62
-    new querki.location.LocationEcot(ecology)                      // 63
-    new models.ModelEcot(ecology)                                  // 64
-    new querki.history.HistoryEcot(ecology)                        // 65
-    new querki.identity.InvitationNotifierEcot(ecology)            // 66
-    new querki.email.UnsubscribeEcot(ecology)                      // 67
-    new querki.publication.PublicationEcot(ecology)                // 68
-    new querki.typeclass.TypeclassEcot(ecology)                    // 69
-    new querki.aws.AWSEcot(ecology)                                // 70
-    new querki.console.ConsoleEcot(ecology)                        // 71
-    new querki.identity.IdentityCommands(ecology)                  // 72
-    new querki.datamodel.ChoiceEcot(ecology)                       // 73
-    new querki.notifications.UserlandNotifierEcot(ecology)         // 74
-                                    // 75
-    new querki.graphql.GraphQLEcot(ecology)                        // 76
-    new querki.debugging.DebuggingEcot(ecology)                    // 77
+    new querki.system.TOSModule(ecology) // 8
+    new querki.logic.LogicModule(ecology) // 9
+    new querki.types.impl.TypesModule(ecology) // 10
+    new querki.html.UIModule(ecology) // 11
+    new querki.types.DeriveNameModule(ecology) // 12
+    new querki.editing.EditorModule(ecology) // 13
+    new querki.identity.skilllevel.impl.SkillLevelModule(ecology) // 14
+    new querki.conventions.ConventionsModule(ecology) // 15
+    new querki.core.CoreModule(ecology) // 16
+    new querki.basic.BasicModule(ecology) // 17
+    // 18
+    new querki.search.SearchEcot(ecology) // 19
+    new querki.core.PropListManagerEcot(ecology) // 20
+    new querki.datamodel.DataModelAccessEcot(ecology) // 21
+    new querki.tags.TagsEcot(ecology) // 22
+    new querki.text.TextEcot(ecology) // 23
+    new querki.ql.QLEcot(ecology) // 24
+    new querki.spaces.PropTypeMigratorEcot(ecology) // 25
+    new querki.html.HtmlRendererEcot(ecology) // 26
+    new querki.links.LinksEcot(ecology) // 27
+    new querki.spaces.SpacePersistenceEcot(ecology) // 28
+    new querki.evolutions.EvolutionsEcot(ecology) // 29
+    // 30
+    new controllers.PageEventManagerEcot(ecology) // 31
+    new querki.spaces.SpaceChangeManagerEcot(ecology) // 32
+    new querki.imexport.ImexportEcot(ecology) // 33
+    new querki.datamodel.introspection.IntrospectionEcot(ecology) // 34
+    new querki.conversations.ConversationEcot(ecology) // 35
+    new querki.collections.GroupingEcot(ecology) // 36
+    new querki.spaces.SpaceEcot(ecology) // 37
+    // 38
+    new querki.identity.IdentityEcot(ecology) // 39
+    new controllers.NavSectionEcot(ecology) // 40
+    new querki.types.PropPathEcot(ecology) // 41
+    new querki.security.EncryptionEcot(ecology) // 42
+    new querki.admin.AdminEcot(ecology) // 43
+    new querki.uservalues.UserValueEcot(ecology) // 44
+    new querki.uservalues.RatingEcot(ecology) // 45
+    new querki.links.ExternalLinkEcot(ecology) // 46
+    new querki.session.SessionEcot(ecology) // 47
+    new querki.notifications.NotificationEcot(ecology) // 48
+    new querki.notifications.NotificationPersistenceEcot(ecology) // 49
+    new querki.conversations.CommentNotifierEcot(ecology) // 50
+    new querki.security.RolesEcot(ecology) // 51
+    new querki.photos.PhotoEcot(ecology) // 52
+    // 53
+    new querki.api.ClientApiEcot(ecology) // 54
+    new querki.tools.ProfilerEcot(ecology) // 55
+    new querki.api.ApiManagement(ecology) // 56
+    new querki.time.DurationEcot(ecology) // 57
+    new querki.cluster.ClusterEcot(ecology) // 58
+    new querki.apps.AppsEcot(ecology) // 59
+    // 60
+    new querki.ql.SignatureEcot(ecology) // 61
+    new querki.core.FunctionEcot(ecology) // 62
+    new querki.location.LocationEcot(ecology) // 63
+    new models.ModelEcot(ecology) // 64
+    new querki.history.HistoryEcot(ecology) // 65
+    new querki.identity.InvitationNotifierEcot(ecology) // 66
+    new querki.email.UnsubscribeEcot(ecology) // 67
+    new querki.publication.PublicationEcot(ecology) // 68
+    new querki.typeclass.TypeclassEcot(ecology) // 69
+    new querki.aws.AWSEcot(ecology) // 70
+    new querki.console.ConsoleEcot(ecology) // 71
+    new querki.identity.IdentityCommands(ecology) // 72
+    new querki.datamodel.ChoiceEcot(ecology) // 73
+    new querki.notifications.UserlandNotifierEcot(ecology) // 74
+    // 75
+    new querki.graphql.GraphQLEcot(ecology) // 76
+    new querki.debugging.DebuggingEcot(ecology) // 77
+    // 78
   }
-  
-  def createAllEcots(ecology:Ecology, actorSystem:Option[ActorSystem], asyncInitTarget:ActorRef):Ecology = {
+
+  def createAllEcots(
+    ecology: Ecology,
+    actorSystem: Option[ActorSystem],
+    asyncInitTarget: ActorRef
+  ): Ecology = {
     createTestableEcots(ecology)
     createDBEcots(ecology)
     createStubbableEcots(ecology, actorSystem, asyncInitTarget)
-    
+
     ecology
   }
 }

--- a/querki/scalajvm/app/querki/test/Testing.scala
+++ b/querki/scalajvm/app/querki/test/Testing.scala
@@ -1,0 +1,32 @@
+package querki.test
+
+import querki.globals._
+
+/**
+ * This is a special ecot, which does nothing at runtime, but provides a bit of introspection capability during
+ * unit tests.
+ */
+trait Testing {
+
+  /**
+   * Declares that some event happened.
+   *
+   * Code should insert this as needed *by the tests* to introspect on side-effects that are not otherwise
+   * observable.
+   *
+   * Note that the parameter is intentionally by-name, so this call is basically zero-code at runtime. Put whatever
+   * data structure is needed by the tests as the event -- since it is only constructed at unit-test time, you don't
+   * need to worry much about the cost.
+   *
+   * @param event a data structure that describes what happened
+   */
+  def happened(event: => Any): Unit
+}
+
+class TestingEcot(e: Ecology) extends QuerkiEcot(e) with Testing {
+
+  /**
+   * In the normal runtime environment, this does absolutely nothing.
+   */
+  def happened(event: => Any): Unit = {}
+}

--- a/querki/scalajvm/test/querki/history/HistoryMidFuncs.scala
+++ b/querki/scalajvm/test/querki/history/HistoryMidFuncs.scala
@@ -1,7 +1,6 @@
 package querki.history
 
 import autowire._
-
 import querki.data.{SpaceInfo, TID, ThingInfo}
 import querki.globals._
 import querki.history.HistoryFunctions.{HistorySummary, HistoryVersion}
@@ -17,8 +16,11 @@ trait HistoryMidFuncs {
   /**
    * Fetch the complete history of this Space.
    */
-  def getHistorySummary(): TestOp[HistorySummary] =
-    TestOp.client { _[HistoryFunctions].getHistorySummary().call() }
+  def getHistorySummary(
+    end: Option[HistoryVersion],
+    nRecords: Int
+  ): TestOp[HistorySummary] =
+    TestOp.client { _[HistoryFunctions].getHistorySummary(end, nRecords).call() }
 
   /**
    * Rolls this Space back to the specified version. The UI should do confirmation first!

--- a/querki/scalajvm/test/querki/history/HistoryMidFuncs.scala
+++ b/querki/scalajvm/test/querki/history/HistoryMidFuncs.scala
@@ -2,9 +2,9 @@ package querki.history
 
 import autowire._
 
-import querki.data.{TID, SpaceInfo, ThingInfo}
+import querki.data.{SpaceInfo, TID, ThingInfo}
 import querki.globals._
-import querki.history.HistoryFunctions.{HistoryVersion, HistorySummary}
+import querki.history.HistoryFunctions.{HistorySummary, HistoryVersion}
 import querki.test.mid._
 
 trait HistoryMidFuncs {
@@ -33,6 +33,25 @@ trait HistoryMidFuncs {
    */
   def restoreDeletedThing(tid: TID): TestOp[ThingInfo] =
     TestOp.client { _[HistoryFunctions].restoreDeletedThing(tid).call() }
+
+  //////////////////////////
+  //
+  // Utility functions
+  //
+
+  def withHistoryVersion[T](v: HistoryVersion)(op: TestOp[T]): TestOp[T] = {
+    for {
+      oldClientState <- TestOp.fetch(_.client)
+      _ <- TestOp.update(state =>
+        TestState.clientL.modify { clientState =>
+          clientState.copy(currentPageParams =
+            clientState.currentPageParams + (HistoryFunctions.viewingHistoryParam -> v.toString))
+        }(state)
+      )
+      t <- op
+      _ <- TestOp.update(state => TestState.clientL.set(oldClientState)(state))
+    } yield t
+  }
 }
 
 object HistoryMidFuncs extends HistoryMidFuncs

--- a/querki/scalajvm/test/querki/test/QuerkiTests.scala
+++ b/querki/scalajvm/test/querki/test/QuerkiTests.scala
@@ -1,37 +1,41 @@
 package querki.test
 
-import akka.actor.{ActorRef, Actor, ActorSystem, Props}
+import akka.actor.{Actor, ActorRef, ActorSystem, Props}
 import akka.cluster.sharding.ShardRegion
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
-import models.{Thing, OID}
+import models.{OID, Thing}
 import querki.core.QLText
 import querki.ecology._
-import querki.globals.{awaitIntentionally, Ecology, QLog, EcologyInterface, EcologyMember, QuerkiEcot}
+import querki.globals.{awaitIntentionally, Ecology, EcologyInterface, EcologyMember, QLog, QuerkiEcot}
 import querki.identity.User
 import querki.time.{DateTime, TimeProvider}
-import querki.values.{SpaceState, QLContext, RequestContext, PropAndVal}
+import querki.values.{PropAndVal, QLContext, RequestContext, SpaceState}
 
-class QuerkiTests 
-  extends WordSpec
-  with Matchers
-  with BeforeAndAfterAll
-  with EcologyMember
-{
-  implicit var ecology:Ecology = null
-  
+class QuerkiTests extends WordSpec with Matchers with BeforeAndAfterAll with EcologyMember {
+  implicit var ecology: Ecology = null
+
   QLog.runningUnitTests = true
-  
+
   lazy val Core = interface[querki.core.Core]
   lazy val Basic = interface[querki.basic.Basic]
   lazy val QL = interface[querki.ql.QL]
   lazy val Links = interface[querki.links.Links]
-  
+
   lazy val ExactlyOne = Core.ExactlyOne
   lazy val Optional = Core.Optional
   lazy val QList = Core.QList
-  
-  class SystemEcotSemiStub(e:Ecology, aso:Option[ActorSystem]) extends querki.system.SystemEcot(e, aso, Actor.noSender) {
-    override def createShardRegion(name:String, props:Props, identityExtractor:ShardRegion.ExtractEntityId, identityResolver:ShardRegion.ExtractShardId) = {
+
+  class SystemEcotSemiStub(
+    e: Ecology,
+    aso: Option[ActorSystem]
+  ) extends querki.system.SystemEcot(e, aso, Actor.noSender) {
+
+    override def createShardRegion(
+      name: String,
+      props: Props,
+      identityExtractor: ShardRegion.ExtractEntityId,
+      identityResolver: ShardRegion.ExtractShardId
+    ) = {
       Some(ActorRef.noSender)
     }
   }
@@ -50,8 +54,8 @@ class QuerkiTests
   }
 
   /**
-    * Use this to control the current time during testing.
-    */
+   * Use this to control the current time during testing.
+   */
   def setTime(time: DateTime): Unit = {
     ecology.api[querki.time.TimeProvider].asInstanceOf[ControllableTimeProvider].setTime(time)
   }
@@ -61,7 +65,7 @@ class QuerkiTests
    * that is not required -- feel free to override this with a version that instantiates only some of them,
    * and stubs out others.
    */
-  def createEcots(e:Ecology): Unit = {
+  def createEcots(e: Ecology): Unit = {
     querki.system.SystemCreator.createTestableEcots(e)
 
     // Testable stubs:
@@ -69,8 +73,9 @@ class QuerkiTests
     new SystemEcotSemiStub(e, None)
     new UserAccessStub(e)
     new ControllableTimeProvider(e)
+    new RealTestingEcot(e)
   }
-  
+
   def createEcology() = {
     val e = new EcologyImpl(None)
     createEcots(e)
@@ -78,101 +83,149 @@ class QuerkiTests
     e.api[querki.system.SystemManagement].setState(state)
     ecology = e
   }
-  
-  def getRcs[S <: TestSpace](state:SpaceState)(implicit space:S, requester:User = BasicTestUser):RequestContext = {
+
+  def getRcs[S <: TestSpace](
+    state: SpaceState
+  )(implicit
+    space: S,
+    requester: User = BasicTestUser
+  ): RequestContext = {
     SimpleTestRequestContext(space.owner.mainIdentity.id)
   }
-  def getRc[S <: TestSpace](implicit space:S, requester:User = BasicTestUser):RequestContext = {
+
+  def getRc[S <: TestSpace](
+    implicit
+    space: S,
+    requester: User = BasicTestUser
+  ): RequestContext = {
     getRcs(space.state)
   }
-  
+
   /**
    * The current easiest way to declare a typical QL test. You must have declared an implicit CommonSpace or
    * descendant for this to work, but it's very boilerplate-light. Note that this supplies the Space itself
    * as the context, so you will usually need to specify explicit context at the beginning of the QL expression.
    */
-  def pql[S <: TestSpace](text:String)(implicit space:S, requester:User = BasicTestUser):String = {
+  def pql[S <: TestSpace](
+    text: String
+  )(implicit
+    space: S,
+    requester: User = BasicTestUser
+  ): String = {
     pqls(text, space.state)
   }
-  def pqls[S <: TestSpace](text:String, state:SpaceState)(implicit space:S, requester:User = BasicTestUser):String = {
+
+  def pqls[S <: TestSpace](
+    text: String,
+    state: SpaceState
+  )(implicit
+    space: S,
+    requester: User = BasicTestUser
+  ): String = {
     val rc = getRcs(state)
     val context = state.thisAsContext(rc, state, ecology)
     processQText(context, text)
   }
-  def pqlt[S <: TestSpace](t:Thing, text:String)(implicit space:S, requester:User = BasicTestUser):String = {
+
+  def pqlt[S <: TestSpace](
+    t: Thing,
+    text: String
+  )(implicit
+    space: S,
+    requester: User = BasicTestUser
+  ): String = {
     implicit val state = space.state
     implicit val rc = getRcs(state)
     val context = t.thisAsContext
     processQText(context, text, Some(t))
   }
 
-  implicit class testableString(str:String) {
+  implicit class testableString(str: String) {
     // Multi-line test strings should use this, to deal with Unix vs. Windows problems:
-    def stripReturns:String = str.replace("\r", "").stripMargin
-    
-    def trimStart(str:String):String = {
+    def stripReturns: String = str.replace("\r", "").stripMargin
+
+    def trimStart(str: String): String = {
       str.indexWhere(c => c != ' ' && c != '\t') match {
         case -1 => ""
-        case n => str.substring(n)
+        case n  => str.substring(n)
       }
     }
-    
+
     // Similar to stripReturns, but instead of using stripMargin, we trim the front of the line.
-    def strip:String = str.replace("\r", "").lines.map(trimStart(_)).mkString("\n")
+    def strip: String = str.replace("\r", "").lines.map(trimStart(_)).mkString("\n")
   }
-    
+
   // Just for efficiency, we create the CommonSpace once -- it is immutable, and good enough for
   // most purposes:
-  var commonSpace:CommonSpace = null
+  var commonSpace: CommonSpace = null
+
   override def beforeAll() = {
     createEcology
     commonSpace = new CommonSpace
   }
   def commonState = commonSpace.state
-  
-  def processQText(context:QLContext, text:String, lexicalOpt:Option[Thing] = None):String = {
+
+  def processQText(
+    context: QLContext,
+    text: String,
+    lexicalOpt: Option[Thing] = None
+  ): String = {
     import scala.concurrent._
     import scala.concurrent.duration._
-    
+
     val qt = QLText(text)
     val wikitext = Await.result(QL.process(qt, context, None, lexicalOpt), 1 second)
     wikitext.plaintext.stripReturns
   }
-  
-  def spaceAndThing[S <: CommonSpace](space:S, f: S => Thing):(SpaceState, Thing) = {
+
+  def spaceAndThing[S <: CommonSpace](
+    space: S,
+    f: S => Thing
+  ): (SpaceState, Thing) = {
     val thing = f(space)
     (space.state, thing)
   }
-  
+
   /**
    * Note that, by default, requests are made by the BasicTestUser, who has nothing to do with this Space.
    * To make the request in the name of the owner or a member instead, set an implicit User in the test.
    */
-  def thingAsContext[S <: CommonSpace](space:S, f: S => Thing)(implicit requester:User = BasicTestUser):QLContext = {
+  def thingAsContext[S <: CommonSpace](
+    space: S,
+    f: S => Thing
+  )(implicit
+    requester: User = BasicTestUser
+  ): QLContext = {
     val (state, thing) = spaceAndThing(space, f)
     val rc = SimpleTestRequestContext(space.owner.mainIdentity.id)
     thing.thisAsContext(rc, state, ecology)
   }
-  
-  def commonThingAsContext(f: CommonSpace => Thing)(implicit requester:User = BasicTestUser):QLContext = thingAsContext(commonSpace, f)
-  
+
+  def commonThingAsContext(f: CommonSpace => Thing)(implicit requester: User = BasicTestUser): QLContext =
+    thingAsContext(commonSpace, f)
+
   /**
    * This is a variant of thingAsContext, intended for use when we have "saved" and "loaded" the state, so we
    * aren't directly using a derivative of CommonSpace.
    */
-  def loadedContext(state:SpaceState, id:OID)(implicit requester:User = BasicTestUser):QLContext = {
+  def loadedContext(
+    state: SpaceState,
+    id: OID
+  )(implicit
+    requester: User = BasicTestUser
+  ): QLContext = {
     val thing = state.anything(id).get
     val rc = SimpleTestRequestContext(state.owner)
     thing.thisAsContext(rc, state, ecology)
   }
-  
+
   /**
    * The standard rendering for a single Link that makes its way to the output.
    */
-  def linkText(t:Thing):String = {
+  def linkText(t: Thing): String = {
     // This is a bit convoluted, but is what we actually display in the link text. Indeed, it's
     // arguably insufficient -- we should be factoring nameOrComputed into here.
-    def fullLookupDisplayName:Option[PropAndVal[_]] = {
+    def fullLookupDisplayName: Option[PropAndVal[_]] = {
       val dispOpt = t.localProp(DisplayNameProp)
       if (dispOpt.isEmpty || dispOpt.get.isEmpty)
         t.localProp(Core.NameProp)
@@ -182,48 +235,48 @@ class QuerkiTests
 
     val display = awaitIntentionally(fullLookupDisplayName.get.renderPlain).raw
     val name = t.canonicalName.map(querki.core.NameUtils.toUrl(_)).getOrElse(display)
-    "[" + display + "](" + name + ")"     
+    "[" + display + "](" + name + ")"
   }
-  
+
   def listOf(strs: String*): String = {
     strs.map { str => s"\n$str" }.mkString
   }
-  
+
   /**
    * Given a list of expected Things that comes out at the end of a QL expression, this is the
    * wikitext for their rendered Links. Note that this is *specifically* for a List or Set.
    * If you have ExactlyOne or Optional, use linkText() instead -- the rendering is slightly
    * different.
    */
-  def listOfLinkText(things:Thing*):String = {
+  def listOfLinkText(things: Thing*): String = {
     val lines = things.map { t =>
       "\n" + linkText(t)
     }
     lines.mkString
   }
-  
-  def listOfLinkText(ids:OID*)(implicit state:SpaceState):String = {
+
+  def listOfLinkText(ids: OID*)(implicit state: SpaceState): String = {
     val things = ids.map(state.anything(_).get)
-    listOfLinkText(things:_*)
+    listOfLinkText(things: _*)
   }
-  
-  def oneTag(tag:String):String = {
+
+  def oneTag(tag: String): String = {
     s"[$tag](${tag.replace(" ", "+")})"
   }
-  
-  def listOfTags(tags:String*):String = {
+
+  def listOfTags(tags: String*): String = {
     val lines = tags.map(tag => s"\n[$tag](${tag.replace(" ", "+")})")
     lines.mkString
   }
-  
-  def expectedWarning(warningName:String):String = s"{{_warning:$warningName}}"
-  
+
+  def expectedWarning(warningName: String): String = s"{{_warning:$warningName}}"
+
   // This is the non-error display of a Tag literal that is unknown
   // TODO: this *should* just reuse oneTag() -- but it can't, because the URL from unknownName (in
   // QLEcot.UnknownNameType) doesn't match the one for Tags (in TagsEcot.TagThing)! These really
   // should be reconciled...
-  def unknownName(name:String):String = s"{{_unknownName:[$name](${name.replace(" ", "-")})}}"
-  
+  def unknownName(name: String): String = s"{{_unknownName:[$name](${name.replace(" ", "-")})}}"
+
   // Commonly used Ecots and pieces therein:
   lazy val DisplayNameProp = interface[querki.basic.Basic].DisplayNameProp
 

--- a/querki/scalajvm/test/querki/test/RealTestingEcot.scala
+++ b/querki/scalajvm/test/querki/test/RealTestingEcot.scala
@@ -1,0 +1,33 @@
+package querki.test
+
+import querki.globals._
+
+trait TestingControls {
+  def getEvents(): List[Any]
+  def clearEvents(): Unit
+}
+
+class RealTestingEcot(e: Ecology) extends QuerkiEcot(e) with Testing with TestingControls {
+
+  /**
+   * Accumulated test data.
+   *
+   * @param events the list of events since last cleared, in reverse order
+   */
+  case class TestData(events: List[Any])
+
+  // TODO: this should really be an AtomicReference, or better yet a Ref, but we need to upgrade the whole
+  // stack a ways before that works easily:
+  var testData: TestData = TestData(List.empty)
+
+  def happened(event: => Any): Unit = synchronized {
+    val e: Any = event
+    testData = testData.copy(events = e :: testData.events)
+  }
+
+  def getEvents() = testData.events.reverse
+
+  def clearEvents() = synchronized {
+    testData = testData.copy(events = List.empty)
+  }
+}

--- a/querki/scalajvm/test/querki/test/mid/ClientFuncs.scala
+++ b/querki/scalajvm/test/querki/test/mid/ClientFuncs.scala
@@ -21,14 +21,12 @@ trait ClientFuncs {
   implicit lazy val clientFuncs = this
 
   lazy val querkiVersion: String = querki.BuildInfo.version
-  // TODO: we eventually want to be able to let tests populate this map, which becomes the metadata
-  // sent in API calls. That is probably another variant of ClientBase?
-  val currentPageParams: Map[String, String] = Map.empty
 
   trait ClientBase extends autowire.Client[String, upickle.default.Reader, upickle.default.Writer] {
     implicit def session: Session
     def harness: HarnessInfo
     def callApi(req: FakeRequest[AnyContentAsFormUrlEncoded]): Future[Result]
+    def currentPageParams: Map[String, String]
 
     implicit lazy val materializer = harness.app.materializer
     def controller = harness.controller[ClientController]
@@ -113,7 +111,8 @@ trait ClientFuncs {
 
   class NSClient(
     val harness: HarnessInfo,
-    val session: Session
+    val session: Session,
+    val currentPageParams: Map[String, String]
   ) extends ClientBase {
 
     def callApi(request: FakeRequest[AnyContentAsFormUrlEncoded]): Future[Result] = {
@@ -124,7 +123,8 @@ trait ClientFuncs {
   class Client(
     val harness: HarnessInfo,
     spaceInfo: SpaceInfo,
-    val session: Session
+    val session: Session,
+    val currentPageParams: Map[String, String]
   ) extends ClientBase {
 
     def callApi(request: FakeRequest[AnyContentAsFormUrlEncoded]): Future[Result] = {

--- a/querki/scalajvm/test/querki/test/mid/ClientState.scala
+++ b/querki/scalajvm/test/querki/test/mid/ClientState.scala
@@ -4,13 +4,21 @@ import play.api.mvc.{Result, Session}
 import monocle.Lens
 import monocle.macros.GenLens
 import org.scalactic.source.Position
-import querki.data.{TID, SpaceInfo, UserInfo}
+import querki.data.{SpaceInfo, TID, UserInfo}
 
 /**
  * Describes the state of the "client" -- the current User, their session info, the Space they are looking at, and
  * so on.
  */
-case class ClientState(std: StdThings, testUser: TestUser, userInfo: Option[UserInfo], session: Session, spaceOpt: Option[SpaceInfo]) {
+case class ClientState(
+  std: StdThings,
+  testUser: TestUser,
+  userInfo: Option[UserInfo],
+  session: Session,
+  spaceOpt: Option[SpaceInfo],
+  currentPageParams: Map[String, String] = Map.empty
+) {
+
   /**
    * Evolves the current state based on the given Result Future.
    */
@@ -22,17 +30,21 @@ case class ClientState(std: StdThings, testUser: TestUser, userInfo: Option[User
   }
 }
 
-object ClientState {  
+object ClientState {
   lazy val empty = ClientState(StdThings(Map.empty), TestUser.Anonymous, None, new Session(), None)
-  
+
   val save: TestOp[ClientState] = TestOp.fetch(_.client)
-  def restore(clientState: ClientState): TestOp[Unit] = TestOp.update(state => TestState.clientL.set(clientState)(state))
+
+  def restore(clientState: ClientState): TestOp[Unit] =
+    TestOp.update(state => TestState.clientL.set(clientState)(state))
 
   /**
    * Stores the current version of the ClientState in the cache. This should generally be done just before switching to a
    * different user.
    */
-  val cache: TestOp[Unit] = TestOp.update(state => TestState.clientCacheL.modify(_ + (state.client.testUser.base -> state.client))(state))
+  val cache: TestOp[Unit] =
+    TestOp.update(state => TestState.clientCacheL.modify(_ + (state.client.testUser.base -> state.client))(state))
+
   /**
    * Switches to a different active user. This user must have previously been cached!
    */
@@ -41,8 +53,7 @@ object ClientState {
       _ <- cache
       userState <- fetchUserState(user)
       _ <- TestOp.update(state => TestState.clientL.set(userState)(state))
-    }
-      yield ()
+    } yield ()
   }
 
   def fetchUserState(user: TestUser)(implicit pos: Position): TestOp[ClientState] = {
@@ -52,40 +63,37 @@ object ClientState {
       state <-
         cache.get(baseName) match {
           case Some(state) => TestOp.pure(state)
-          case None => TestOp.error(new Exception(s"Unable to find state for a user named '$baseName'!"))
+          case None        => TestOp.error(new Exception(s"Unable to find state for a user named '$baseName'!"))
         }
-    }
-      yield state
+    } yield state
   }
 
   /**
-    * Performs the specified operation with the specified user, and then restores the current user.
-    */
+   * Performs the specified operation with the specified user, and then restores the current user.
+   */
   def withUser[T](user: TestUser)(op: TestOp[T]): TestOp[T] = {
     for {
       originalUser <- TestOp.fetch(_.client.testUser)
       _ <- switchToUser(user)
       t <- op
       _ <- switchToUser(originalUser)
-    }
-      yield t
+    } yield t
   }
 
   /**
-    * Performs the specified operation, and then pop the original user back out at the end.
-    */
+   * Performs the specified operation, and then pop the original user back out at the end.
+   */
   def cachingUser[T](op: TestOp[T]): TestOp[T] = {
     for {
       originalUser <- TestOp.fetch(_.client.testUser)
       t <- op
       _ <- switchToUser(originalUser)
-    }
-      yield t
+    } yield t
   }
 
   /**
-    * Fetch the TID of a user who has previously been created in this test.
-    */
+   * Fetch the TID of a user who has previously been created in this test.
+   */
   def userId(user: TestUser): TestOp[TID] = {
     TestOp.fetch { state =>
       val oid = TestState.clientL.get(state).userInfo


### PR DESCRIPTION
This is a pretty enormous PR -- basically rewriting the entire History system, so that instead of reading the entire history into memory at once (which is now large enough in the SI Playtest Space to bring the entire site down, I believe), we now do it entirely in a proper streaming fashion.  This means that things will sometimes run more slowly, but should be much more reliable.