### PR TITLE
QI.9v5kg2v: Introduce the ability to redirect from a "bad" domain to a "good" one

### DIFF
--- a/querki/scalajvm/app/querki/basic/BasicModule.scala
+++ b/querki/scalajvm/app/querki/basic/BasicModule.scala
@@ -144,7 +144,7 @@ class BasicModule(e: Ecology) extends QuerkiEcot(e) with Basic with WithQL with 
       Categories(BasicTag),
       Summary("A short text that does not contain any QL"),
       Details("""Plain Text is a special, restricted sort of Text. It can contains all of the
-                |formatting described in the [QText Reference](http://www.querki.net/u/systemUser/documentation/QText-Reference),
+                |formatting described in the [QText Reference](http://querki.net/u/systemUser/documentation/QText-Reference),
                 |but it can *not* contain any QL expressions. This means that it can not have simply Links to other Things, and can
                 |not use Properties at all.
                 |

--- a/querki/scalajvm/app/querki/core/Types.scala
+++ b/querki/scalajvm/app/querki/core/Types.scala
@@ -1019,7 +1019,7 @@ trait TypeCreation {
                      |Large Text Properties are mainly composed of QText -- an easy-to-use "markup" format, that lets you
                      |describe concepts like boldface, paragraphs, links, bullet lists and so on in fairly intuitive ways, without
                      |needing to use HTML. For details on all the different things you can do with QText, see
-                     |the [QText Reference](http://www.querki.net/u/systemUser/documentation/QText-Reference).
+                     |the [QText Reference](http://querki.net/u/systemUser/documentation/QText-Reference).
                      |
                      |#### QL
                      |

--- a/querki/scalajvm/app/querki/email/RealEmailSender.scala
+++ b/querki/scalajvm/app/querki/email/RealEmailSender.scala
@@ -204,7 +204,7 @@ private[email] class RealEmailSender(e: Ecology) extends QuerkiEcot(e) with Emai
 
     val body =
       Wikitext("""{{maindiv:
-                 |<div class="logocontainer"><img class="logo" alt="Querki Logo" src="http://www.querki.net/assets/images/Logo-green.png"></div>
+                 |<div class="logocontainer"><img class="logo" alt="Querki Logo" src="http://querki.net/assets/images/Logo-green.png"></div>
                  |
                  |""".stripMargin) +
         bodyWiki +
@@ -300,7 +300,7 @@ private[email] class RealEmailSender(e: Ecology) extends QuerkiEcot(e) with Emai
 
       val body =
         Wikitext("""{{maindiv:
-                   |<div class="logocontainer"><img class="logo" alt="Querki Logo" src="http://www.querki.net/assets/images/Logo-green.png"></div>
+                   |<div class="logocontainer"><img class="logo" alt="Querki Logo" src="http://querki.net/assets/images/Logo-green.png"></div>
                    |
                    |""".stripMargin) +
           bodyMain +

--- a/querki/scalajvm/app/querki/identity/IdentityCommands.scala
+++ b/querki/scalajvm/app/querki/identity/IdentityCommands.scala
@@ -21,7 +21,7 @@ class IdentityCommands(e: Ecology) extends QuerkiEcot(e) {
   lazy val MakeAllPersonsPublicCommand = Console.defineSpaceCommand(
     MakeAllPersonsPublicCommandOID,
     "Make All Persons Public",
-    "This is a one-off command to fix [this bug](https://www.querki.net/u/jducoeur/alpha-issue-tracking/#!.7w4g99b) in your Space",
+    "This is a one-off command to fix [this bug](https://querki.net/u/jducoeur/alpha-issue-tracking/#!.7w4g99b) in your Space",
     Seq(AccessControl.CanEditProp)
   ) { args =>
     val inv = args.inv

--- a/querki/scalajvm/app/querki/identity/InvitationNotifierEcot.scala
+++ b/querki/scalajvm/app/querki/identity/InvitationNotifierEcot.scala
@@ -345,7 +345,7 @@ class InvitationNotifierEcot(e: Ecology) extends QuerkiEcot(e) with Notifier wit
         senderOpt.getOrElse(throw new Exception(s"Somehow got Invitation Unsub from unknown sender $senderId!"))
       (
         Wikitext(s"""**${sender.name}** invited you to join the Querki Space *$spaceName*. 
-                    |[Click here for more information about Querki.](https://www.querki.net/help/#!What-is-Querki) 
+                    |[Click here for more information about Querki.](https://querki.net/help/#!What-is-Querki) 
                     |
                     |Use the buttons below to keep ${sender.name} from inviting you to this or any other Space,
                     |or to suppress Querki invitations entirely.""".stripMargin),

--- a/querki/scalajvm/app/views/index.scala.html
+++ b/querki/scalajvm/app/views/index.scala.html
@@ -28,8 +28,8 @@
 		  </div>
 		</div>
 		
-		<p>For more information about Querki, see <a href="http://www.querki.net/help/#!Learning-Querki">Learning Querki</a> or 
-		the <a href="http://www.querki.net/help/#!Querki-Quickstart">Querki Quickstart page</a>.</p>
+		<p>For more information about Querki, see <a href="http://querki.net/help/#!Learning-Querki">Learning Querki</a> or
+		the <a href="http://querki.net/help/#!Querki-Quickstart">Querki Quickstart page</a>.</p>
 	  }
       case Some(u) => {
 		  <a href="/spaces" class="btn btn-primary">Show my Spaces</a>

--- a/querki/scalajvm/app/views/main.scala.html
+++ b/querki/scalajvm/app/views/main.scala.html
@@ -236,7 +236,7 @@
       <hr class="_noPrint">
 
       <footer class="_mainFooter _noPrint">
-        Querki &copy; Querki Inc 2013-2015 | <a href="http://www.querki.net/help/">Help</a> | <a href="/TOS">Terms of Service</a>
+        Querki &copy; Querki Inc 2013-2022 | <a href="http://querki.net/help/">Help</a> | <a href="/TOS">Terms of Service</a>
       </footer>
 
     </div><!--/.fluid-container-->

--- a/querki/scalajvm/conf/application.conf.template
+++ b/querki/scalajvm/conf/application.conf.template
@@ -42,7 +42,12 @@ querki {
     # semblance of recording of Space ups and downs.
     logMonitor : false
   }
-  
+
+  redirect {
+    from : "www.querki.net"
+    to : "https://querki.net"
+  }
+
   session {
     # Time before a UserSpaceSession times out for inactivity
     timeout : 5 minutes

--- a/querki/scalajvm/test/querki/html/UITests.scala
+++ b/querki/scalajvm/test/querki/html/UITests.scala
@@ -336,7 +336,7 @@ class UITests extends QuerkiTests {
       processQText(commonThingAsContext(_.withUrl), """[[My List of URLs -> _showLink(""hello"")]]""") should
         equal("""
           |<a href="http://www.google.com/" target="_blank">hello</a>
-          |<a href="http://www.querki.net/" target="_blank">hello</a>""".stripReturns)
+          |<a href="http://querki.net/" target="_blank">hello</a>""".stripReturns)
     }
     "work with a list of Links" in {
       class testSpace extends CommonSpace {

--- a/querki/scalajvm/test/querki/qtext/TransformerTest.scala
+++ b/querki/scalajvm/test/querki/qtext/TransformerTest.scala
@@ -413,14 +413,14 @@ And now to something completely different.
   }
 
   it should "allow HTTP URLs" in {
-    apply("[Querki](http://www.querki.net/)") should equal(
-      "<p><a href=\"http://www.querki.net/\" rel=\"nofollow\" target=\"_blank\">Querki</a></p>\n"
+    apply("[Querki](http://querki.net/)") should equal(
+      "<p><a href=\"http://querki.net/\" rel=\"nofollow\" target=\"_blank\">Querki</a></p>\n"
     )
   }
 
   it should "allow HTTPS URLs" in {
-    apply("[Querki](https://www.querki.net/)") should equal(
-      "<p><a href=\"https://www.querki.net/\" rel=\"nofollow\" target=\"_blank\">Querki</a></p>\n"
+    apply("[Querki](https://querki.net/)") should equal(
+      "<p><a href=\"https://querki.net/\" rel=\"nofollow\" target=\"_blank\">Querki</a></p>\n"
     )
   }
 
@@ -429,17 +429,17 @@ And now to something completely different.
   }
 
   it should "prevent all forms of Javascript injection" in {
-    apply("[Evil](javascript://www.querki.net/)") should equal(
-      "<p><a href=\"./javascript://www.querki.net/\" rel=\"nofollow\" target=\"_blank\">Evil</a></p>\n"
+    apply("[Evil](javascript://querki.net/)") should equal(
+      "<p><a href=\"./javascript://querki.net/\" rel=\"nofollow\" target=\"_blank\">Evil</a></p>\n"
     )
-    apply("[Evil](javascript+://www.querki.net/)") should equal(
-      "<p><a href=\"./javascript+://www.querki.net/\" rel=\"nofollow\" target=\"_blank\">Evil</a></p>\n"
+    apply("[Evil](javascript+://querki.net/)") should equal(
+      "<p><a href=\"./javascript+://querki.net/\" rel=\"nofollow\" target=\"_blank\">Evil</a></p>\n"
     )
-    apply("[Evil](javascript-://www.querki.net/)") should equal(
-      "<p><a href=\"./javascript-://www.querki.net/\" rel=\"nofollow\" target=\"_blank\">Evil</a></p>\n"
+    apply("[Evil](javascript-://querki.net/)") should equal(
+      "<p><a href=\"./javascript-://querki.net/\" rel=\"nofollow\" target=\"_blank\">Evil</a></p>\n"
     )
-    apply("[Evil](javascript.://www.querki.net/)") should equal(
-      "<p><a href=\"./javascript.://www.querki.net/\" rel=\"nofollow\" target=\"_blank\">Evil</a></p>\n"
+    apply("[Evil](javascript.://querki.net/)") should equal(
+      "<p><a href=\"./javascript.://querki.net/\" rel=\"nofollow\" target=\"_blank\">Evil</a></p>\n"
     )
   }
 

--- a/querki/scalajvm/test/querki/test/CommonSpace.scala
+++ b/querki/scalajvm/test/querki/test/CommonSpace.scala
@@ -84,7 +84,7 @@ class CommonSpace(implicit ecologyIn: Ecology) extends TestSpace {
     withUrlOID,
     "With URL",
     optURLProp("http://www.google.com/"),
-    listURLProp("http://www.google.com/", "http://www.querki.net/")
+    listURLProp("http://www.google.com/", "http://querki.net/")
   )
 
   val withoutUrl = new SimpleTestThing("Without URL", optURLProp())

--- a/querki/scalajvm/test/querki/test/regression/RegressionTests.scala
+++ b/querki/scalajvm/test/querki/test/regression/RegressionTests.scala
@@ -10,7 +10,7 @@ import querki.test._
  * @author jducoeur
  */
 class RegressionTests extends QuerkiTests {
-  // See https://www.querki.net/u/jducoeur/alpha-issue-tracking/#.3y28a3r
+  // See https://querki.net/u/jducoeur/alpha-issue-tracking/#.3y28a3r
   ".3y28a3r" should {
     "be fixed" in {
       class TSpace extends CommonSpace {


### PR DESCRIPTION
In practice, this is all about redirecting from `www.querki.net` to `querki.net`, so users stop having cookie problems.

This changes all of the hard-coded URLs to the normal `querki.net`.

The actual redirection will come from config, in production.