### PR TITLE
Upgrade ScalaTest

### DIFF
--- a/querki/.gitignore
+++ b/querki/.gitignore
@@ -23,3 +23,4 @@ localsecrets.conf
 aws_creds
 /localsecrets.cass3.conf
 /localsecrets.cass4.conf
+/.claude

--- a/querki/build.sbt
+++ b/querki/build.sbt
@@ -115,8 +115,8 @@ lazy val querkiServer = (project in file("scalajvm")).settings(
     // TEST-ONLY DEPENDENCIES:
     // ScalaTest can't upgrade until scalatestplus-play does, and *that* can't upgrade until we hit Play 2.8. So
     // this is a bit stuck for now:
-    "org.scalatest" %% "scalatest" % "3.0.8" % "test",
-    "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.3" % "test",
+    "org.scalatest" %% "scalatest" % "3.1.4" % "test",
+    "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % "test",
     // Powerful structural-diffing library: https://github.com/xdotai/diff
     // This will need replacing with a different library after Scala 2.12!
 //    "ai.x" %% "diff" % "2.0.1" % "test",

--- a/querki/scalajvm/conf/application.conf.template
+++ b/querki/scalajvm/conf/application.conf.template
@@ -202,7 +202,7 @@ play-akka {
     cluster {
       # This is the fallback setup, for when we're not actually running under ConductR:
       seed-nodes = [
-        "akka.tcp://application@127.0.0.1:2552"
+        "akka://application@127.0.0.1:2552"
       ]
     }
   }
@@ -226,7 +226,7 @@ akka {
   cluster {
     # This is the fallback setup, for when we're not actually running under ConductR:
     seed-nodes = [
-       "akka.tcp://local-querki-server@127.0.0.1:2551"
+       "akka://local-querki-server@127.0.0.1:2551"
     ]
   }
     

--- a/querki/scalajvm/conf/scenario.conf
+++ b/querki/scalajvm/conf/scenario.conf
@@ -131,19 +131,27 @@ scenario {
   akka.actor.warn-about-java-serializer-usage : false
 
   akka {
+
     remote {
-      netty.tcp {
-        port = 2551
+      artery {
+        canonical {
+          hostname = "127.0.0.1"
+          port = 2553
+        }
       }
+      #netty.tcp {
+      #  port = 2553
+      #}
     }
 
     cluster {
       seed-nodes = [
-        "akka.tcp://application@127.0.0.1:2551"
+        "akka://application@127.0.0.1:2553"
       ]
     }
 
     actor {
+      provider = "cluster"
     }
   }
 
@@ -158,9 +166,21 @@ scenario {
 
   play-akka {
     akka {
+      remote {
+        artery {
+          canonical {
+            hostname = "127.0.0.1"
+            port = 2552
+          }
+        }
+        #netty.tcp {
+        #  port = 2553
+        #}
+      }
+
       cluster {
         seed-nodes = [
-          "akka.tcp://application@127.0.0.1:2552"
+          "akka://application@127.0.0.1:2552"
         ]
       }
     }

--- a/querki/scalajvm/conf/testnode.conf
+++ b/querki/scalajvm/conf/testnode.conf
@@ -6,7 +6,7 @@ include "application.conf"
 querki.akka.timeout = 30 seconds
 
 akka.cluster.seed-nodes = [
-      "akka.tcp://application@127.0.0.1:2561",
-      "akka.tcp://application@127.0.0.1:2562",
-      "akka.tcp://application@127.0.0.1:2563"
+      "akka://application@127.0.0.1:2561",
+      "akka://application@127.0.0.1:2562",
+      "akka://application@127.0.0.1:2563"
     ]

--- a/querki/scalajvm/test/org/querki/requester/RequesterTests.scala
+++ b/querki/scalajvm/test/org/querki/requester/RequesterTests.scala
@@ -6,7 +6,9 @@ package org.querki.requester
 import scala.concurrent.duration._
 import akka.actor.{Actor, ActorSystem, Props}
 import akka.testkit.{ImplicitSender, TestKit}
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, Matchers, WordSpecLike}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.should.Matchers
 
 // TODO: the Requester tests are having problems in the integrated application, but for now we don't care.
 // If/when Requester gets lifted back out to its own library, re-enable these tests and get them working right.
@@ -14,7 +16,7 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, Matchers, WordSpecLike}
 class RequesterTests
   extends TestKit(ActorSystem("RequesterTests"))
      with ImplicitSender
-     with WordSpecLike
+     with AnyWordSpecLike
      with Matchers
      with BeforeAndAfterAll {
 

--- a/querki/scalajvm/test/querki/conversations/ConvMidFuncs.scala
+++ b/querki/scalajvm/test/querki/conversations/ConvMidFuncs.scala
@@ -2,7 +2,7 @@ package querki.conversations
 
 import autowire._
 
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 import querki.conversations.messages._
 import querki.data.TID

--- a/querki/scalajvm/test/querki/conversations/ConvMidTests.scala
+++ b/querki/scalajvm/test/querki/conversations/ConvMidTests.scala
@@ -1,7 +1,7 @@
 package querki.conversations
 
 import org.scalatest.tags.Slow
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 import querki.test.mid._
 

--- a/querki/scalajvm/test/querki/ecology/EcologyTests.scala
+++ b/querki/scalajvm/test/querki/ecology/EcologyTests.scala
@@ -1,10 +1,12 @@
 package querki.ecology
 
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
 import querki.values.SpaceState
 
-class EcologyTests extends WordSpec with Matchers with BeforeAndAfterAll {
+class EcologyTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   trait TestInterface1 extends EcologyInterface {}
 
   trait TestInterface2 extends EcologyInterface {

--- a/querki/scalajvm/test/querki/graphql/GraphQLMidTests.scala
+++ b/querki/scalajvm/test/querki/graphql/GraphQLMidTests.scala
@@ -2,7 +2,7 @@ package querki.graphql
 
 import java.nio.charset.StandardCharsets
 
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 import querki.test.mid._
 import AllFuncs._
 import controllers.GraphQLController

--- a/querki/scalajvm/test/querki/graphql/package.scala
+++ b/querki/scalajvm/test/querki/graphql/package.scala
@@ -1,7 +1,7 @@
 package querki
 
 import org.scalactic.source.Position
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 import play.api.libs.json._
 
 package object graphql {

--- a/querki/scalajvm/test/querki/history/HistoryMidTests.scala
+++ b/querki/scalajvm/test/querki/history/HistoryMidTests.scala
@@ -1,7 +1,7 @@
 package querki.history
 
 import org.scalatest.tags.Slow
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 import querki.data.TID
 import querki.test.mid._
 import AllFuncs._

--- a/querki/scalajvm/test/querki/notifications/NotificationMidFuncs.scala
+++ b/querki/scalajvm/test/querki/notifications/NotificationMidFuncs.scala
@@ -2,7 +2,7 @@ package querki.notifications
 
 import autowire._
 import org.scalactic.source.Position
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 import querki.globals.execContext
 import querki.test.mid.ClientState.withUser
 import querki.test.mid._

--- a/querki/scalajvm/test/querki/persistence/PersistenceTests.scala
+++ b/querki/scalajvm/test/querki/persistence/PersistenceTests.scala
@@ -7,7 +7,7 @@ import querki.globals._
 import querki.identity.User
 import querki.test._
 
-trait PersistEnv extends org.scalatest.WordSpecLike with EcologyMember {
+trait PersistEnv extends org.scalatest.wordspec.AnyWordSpecLike with EcologyMember {
   def asrt(a: Boolean)
 
   def checkEquality[T](

--- a/querki/scalajvm/test/querki/publication/PublicationMidTests.scala
+++ b/querki/scalajvm/test/querki/publication/PublicationMidTests.scala
@@ -1,7 +1,7 @@
 package querki.publication
 
 import org.scalatest.tags.Slow
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 import querki.test.mid._
 import AllFuncs._
 import ClientState.withUser

--- a/querki/scalajvm/test/querki/qtext/BaseParsersTest.scala
+++ b/querki/scalajvm/test/querki/qtext/BaseParsersTest.scala
@@ -1,6 +1,7 @@
 package querki.qtext
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import collection.SortedMap
 
 /**
@@ -8,7 +9,7 @@ import collection.SortedMap
  */
 
 //@RunWith(classOf[JUnitRunner])
-class BaseParsersTest extends FlatSpec with Matchers with BaseParsers {
+class BaseParsersTest extends AnyFlatSpec with Matchers with BaseParsers {
 
   "The BaseParsers" should "parse a newline" in {
     val p = nl

--- a/querki/scalajvm/test/querki/qtext/BlockParsersTest.scala
+++ b/querki/scalajvm/test/querki/qtext/BlockParsersTest.scala
@@ -1,12 +1,13 @@
 package querki.qtext
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Tests the parsing on block level.
  */
 //@RunWith(classOf[JUnitRunner])
-class BlockParsersTest extends FlatSpec with Matchers with BlockParsers {
+class BlockParsersTest extends AnyFlatSpec with Matchers with BlockParsers {
 
   def deco() = new MainDecorator {}
 

--- a/querki/scalajvm/test/querki/qtext/InlineParsersTest.scala
+++ b/querki/scalajvm/test/querki/qtext/InlineParsersTest.scala
@@ -1,6 +1,7 @@
 package querki.qtext
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 trait InlineBase { this: InlineParsers with Matchers =>
 
@@ -29,7 +30,7 @@ trait InlineBase { this: InlineParsers with Matchers =>
  * Tests Inline Parsing, i.e. emphasis , strong text, links, escapes etc.
  */
 //@RunWith(classOf[JUnitRunner])
-class InlineParsersTest extends FlatSpec with Matchers with InlineParsers with InlineBase {
+class InlineParsersTest extends AnyFlatSpec with Matchers with InlineParsers with InlineBase {
 
   def deco() = new MainDecorator {}
 

--- a/querki/scalajvm/test/querki/qtext/LineParsersTest.scala
+++ b/querki/scalajvm/test/querki/qtext/LineParsersTest.scala
@@ -1,12 +1,13 @@
 package querki.qtext
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * tests parsing of individual lines
  */
 //@RunWith(classOf[JUnitRunner])
-class LineParsersTest extends FlatSpec with Matchers with LineParsers {
+class LineParsersTest extends AnyFlatSpec with Matchers with LineParsers {
 
   def deco() = new MainDecorator {}
 

--- a/querki/scalajvm/test/querki/qtext/LineTokenizerTest.scala
+++ b/querki/scalajvm/test/querki/qtext/LineTokenizerTest.scala
@@ -1,12 +1,13 @@
 package querki.qtext
 
-import org.scalatest.{FlatSpecLike, Matchers}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Tests the Line Tokenizer that prepares input for parsing.
  */
 //@RunWith(classOf[JUnitRunner])
-class LineTokenizerTest extends LineTokenizer(new MainDecorator {}) with FlatSpecLike with Matchers {
+class LineTokenizerTest extends LineTokenizer(new MainDecorator {}) with AnyFlatSpecLike with Matchers {
 
   "The LineTokenizer" should "split input lines correctly" in {
     splitLines("line1\nline2\n") should equal(List("line1", "line2"))

--- a/querki/scalajvm/test/querki/qtext/TransformerTest.scala
+++ b/querki/scalajvm/test/querki/qtext/TransformerTest.scala
@@ -1,6 +1,7 @@
 package querki.qtext
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Tests the behavior of the complete parser, i.e. all parsing steps together.
@@ -11,7 +12,7 @@ import org.scalatest.{FlatSpec, Matchers}
  * Package Explorer, and do File -> Convert Line Delimiters To -> Unix.
  */
 //@RunWith(classOf[JUnitRunner])
-class TransformerTest extends FlatSpec with Matchers with Transformer with MainDecorator {
+class TransformerTest extends AnyFlatSpec with Matchers with Transformer with MainDecorator {
 
   implicit class testableString(str: String) {
     // Multi-line test strings should use this, to deal with Unix vs. Windows problems:

--- a/querki/scalajvm/test/querki/security/SecurityMidTests.scala
+++ b/querki/scalajvm/test/querki/security/SecurityMidTests.scala
@@ -1,7 +1,7 @@
 package querki.security
 
 import org.scalatest.tags.Slow
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 import querki.data.TID
 import querki.test.mid._
 import AllFuncs._

--- a/querki/scalajvm/test/querki/spaces/SpaceMidTests.scala
+++ b/querki/scalajvm/test/querki/spaces/SpaceMidTests.scala
@@ -1,7 +1,7 @@
 package querki.spaces
 
 import org.scalatest.tags.Slow
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 import querki.data.TID
 import querki.test.mid._
 import AllFuncs._

--- a/querki/scalajvm/test/querki/test/QuerkiTests.scala
+++ b/querki/scalajvm/test/querki/test/QuerkiTests.scala
@@ -2,7 +2,9 @@ package querki.test
 
 import akka.actor.{Actor, ActorRef, ActorSystem, Props}
 import akka.cluster.sharding.ShardRegion
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 import models.{OID, Thing}
 import querki.core.QLText
 import querki.ecology._
@@ -11,7 +13,7 @@ import querki.identity.User
 import querki.time.{DateTime, TimeProvider}
 import querki.values.{PropAndVal, QLContext, RequestContext, SpaceState}
 
-class QuerkiTests extends WordSpec with Matchers with BeforeAndAfterAll with EcologyMember with QLogging {
+class QuerkiTests extends AnyWordSpec with Matchers with BeforeAndAfterAll with EcologyMember with QLogging {
   implicit var ecology: Ecology = null
 
   QLog.runningUnitTests = true

--- a/querki/scalajvm/test/querki/test/functional/FuncUtil.scala
+++ b/querki/scalajvm/test/querki/test/functional/FuncUtil.scala
@@ -50,7 +50,7 @@ trait FuncUtil extends FuncData with FuncMenu with FuncEditing with FuncTypes wi
    * When we *can* upgrade past this inconsistency, we should.
    */
   @nowarn
-  implicit val browser: org.scalatest.selenium.WebBrowser = this
+  implicit val browser: org.scalatestplus.selenium.WebBrowser = this
 
   /**
    * This works around the very unfortunate limitation that WebBrowser.Element doesn't allow

--- a/querki/scalajvm/test/querki/test/functional/QuerkiFuncTests.scala
+++ b/querki/scalajvm/test/querki/test/functional/QuerkiFuncTests.scala
@@ -2,6 +2,8 @@ package querki.test.functional
 
 import play.api.{Application, ApplicationLoader, Environment}
 import org.scalatest._
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.play._
 import org.scalatestplus.play.guice.GuiceOneServerPerTest
 import querki.globals._
@@ -14,7 +16,7 @@ import querki.system.{QuerkiApplicationLoader, QuerkiRoot}
  * This keep recompiles down to a manageable level.
  */
 trait FuncMixin
-  extends WordSpec
+  extends AnyWordSpec
      with Matchers
      with org.scalatest.concurrent.Eventually
      with OneBrowserPerTest // includes WebBrowser
@@ -38,7 +40,7 @@ trait FuncMixin
 @Ignore
 class QuerkiFuncTests
 // Infrastructure mix-ins, from ScalaTest and Play:
-  extends WordSpec
+  extends AnyWordSpec
      with Matchers
      with BeforeAndAfterAll
      with GuiceOneServerPerTest
@@ -73,9 +75,9 @@ class QuerkiFuncTests
    * This is where we override the standard Application settings.
    */
   override implicit def newAppForTest(td: TestData): Application = {
-    val context = ApplicationLoader.createContext(
+    val context = ApplicationLoader.Context.create(
       Environment.simple(),
-      Map(
+      initialSettings = Map(
         // For the moment, the names of the test DBs are hardcoded. That will probably have to
         // change eventually.
         "db.system.url" -> "jdbc:mysql://localhost/test_system?characterEncoding=UTF-8",

--- a/querki/scalajvm/test/querki/test/mid/BasicTests.scala
+++ b/querki/scalajvm/test/querki/test/mid/BasicTests.scala
@@ -1,6 +1,6 @@
 package querki.test.mid
 
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 import org.scalatest.tags.Slow
 import ClientState.{cache, switchToUser, withUser}
 import AllFuncs._

--- a/querki/scalajvm/test/querki/test/mid/LoginFuncs.scala
+++ b/querki/scalajvm/test/querki/test/mid/LoginFuncs.scala
@@ -6,8 +6,7 @@ import cats.data._
 import cats.effect.{ContextShift, IO}
 import upickle.default._
 import autowire._
-import org.scalatest._
-import Matchers._
+import org.scalatest.matchers.should.Matchers._
 import play.api.Application
 import play.api.mvc.{Result, Session}
 import play.api.test.Helpers._

--- a/querki/scalajvm/test/querki/test/mid/MidTestBase.scala
+++ b/querki/scalajvm/test/querki/test/mid/MidTestBase.scala
@@ -28,9 +28,9 @@ trait MidTestBase extends PlaySpec with GuiceOneAppPerTest with EcologyMember {
   override implicit def newAppForTest(testData: TestData): Application = {
     // IMPORTANT: test code runs with an alternate config file, application.test.conf, which
     // enhances the built-in one!
-    val context = ApplicationLoader.createContext(
+    val context = ApplicationLoader.Context.create(
       Environment.simple(),
-      Map(
+      initialSettings = Map(
         // See scenario.conf instead of here
       )
     )

--- a/querki/scalajvm/test/querki/test/mid/PropFuncs.scala
+++ b/querki/scalajvm/test/querki/test/mid/PropFuncs.scala
@@ -1,6 +1,6 @@
 package querki.test.mid
 
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 import autowire._
 import querki.api.ThingFunctions
 import querki.data._

--- a/querki/scalajvm/test/querki/test/mid/ResultHelpers.scala
+++ b/querki/scalajvm/test/querki/test/mid/ResultHelpers.scala
@@ -3,8 +3,7 @@ package querki.test.mid
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-import play.api.mvc.{Cookies, Result, Session}
-import play.api.test.Helpers.{SET_COOKIE}
+import play.api.mvc.{Result, Session}
 
 import akka.stream.Materializer
 import akka.util.ByteString
@@ -15,15 +14,7 @@ import akka.util.ByteString
 class ResultHelpers(result: Result) {
   def headers: Map[String, String] = result.header.headers
   def header(name: String): Option[String] = headers.get(name)
-  def cookies: Cookies = Cookies.fromSetCookieHeader(header(SET_COOKIE))
-  // Used to be Session.COOKIE_NAME -- that's now deprecated in favor of injection, but for purposes of testing
-  // it's probably fine to just hardcode it:
-  final val playSessionCookieName = "PLAY_SESSION"
-
-  // For the time being, we're not bothering to decode the session cookie, because the JWT code is giving us
-  // warnings when we try to do this. If it turns out to be a problem in the real running system, revisit this.
-  def sess: Session =
-    result.newSession.getOrElse(Session()) // Session.decodeFromCookie(cookies.get(playSessionCookieName))
+  def sess: Session = result.newSession.getOrElse(Session())
   def status: Int = result.header.status
 
   def charset: Option[String] =

--- a/querki/scalajvm/test/querki/test/mid/SetupFuncs.scala
+++ b/querki/scalajvm/test/querki/test/mid/SetupFuncs.scala
@@ -2,7 +2,7 @@ package querki.test.mid
 
 import querki.data._
 import AllFuncs._
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 import querki.security.SecurityMidFuncs
 
 /**


### PR DESCRIPTION
Code changes are mostly to deal with the resulting deprecations.

Also fixes some scenario test configs to match current reality.

Scenario tests still don't run, though -- we can't enable akka-persistence-inmemory until we get to Scala 2.13.